### PR TITLE
fix center-quote shortcode when config unsafe = false

### DIFF
--- a/layouts/shortcodes/center-quote.html
+++ b/layouts/shortcodes/center-quote.html
@@ -1,3 +1,3 @@
 <blockquote class="blockquote-center">
-  {{ .Inner }}
+  {{ .Inner | .Page.RenderString }}
 </blockquote>


### PR DESCRIPTION
when config unsafe = false, center-quote without markdown works but shortcode with markdown doesn't work.

the following doesn't work when unsafe = false:
```
{{% center-quote %}}
**hello** *world*
this is a center-quote shortcode example.
{{% /center-quote %}}
```

with this fix, the following works with markdown when unsafe = false:
```
{{< center-quote >}}
**hello** *world*
this is a center-quote shortcode example.
{{< /center-quote >}}
```