### PR TITLE
Enable no comments per single page

### DIFF
--- a/layouts/partials/single/comment.html
+++ b/layouts/partials/single/comment.html
@@ -5,286 +5,288 @@
 
 {{- if $comment.enable -}}
   {{- $commentConfig = dict "enable" true "expired" (.Scratch.Get "commentExpired" | default false) -}}
-  <div id="comments">
-    {{- /* Artalk Comment System */ -}}
-    {{- $artalk := $comment.artalk | default dict -}}
-    {{- if $artalk.enable -}}
-      <div id="artalk" class="comment"></div>
-      {{- $source := $cdn.artalkCSS | default "lib/artalk/Artalk.min.css" -}}
-      {{- dict "Source" $source "Minify" true "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/style.html" -}}
-      {{- $source := $cdn.artalkJS | default "lib/artalk/Artalk.min.js" -}}
-      {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
-      {{- $commentConfig = dict "el" "#artalk" "pageKey" .Permalink "pageTitle" .Title "pvEl" "artalk-visitor-count" "countEl" "artalk-comment-count" | dict "artalk" | merge $commentConfig -}}
-      {{- if (eq $artalk.locale "") | and (eq $.Site.LanguageCode "en") -}}
-        {{- $artalk = dict "locale" "en-US" | merge $artalk -}}
+  {{ if not .Params.noComment }}
+    <div id="comments">
+      {{- /* Artalk Comment System */ -}}
+      {{- $artalk := $comment.artalk | default dict -}}
+      {{- if $artalk.enable -}}
+        <div id="artalk" class="comment"></div>
+        {{- $source := $cdn.artalkCSS | default "lib/artalk/Artalk.min.css" -}}
+        {{- dict "Source" $source "Minify" true "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/style.html" -}}
+        {{- $source := $cdn.artalkJS | default "lib/artalk/Artalk.min.js" -}}
+        {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+        {{- $commentConfig = dict "el" "#artalk" "pageKey" .Permalink "pageTitle" .Title "pvEl" "artalk-visitor-count" "countEl" "artalk-comment-count" | dict "artalk" | merge $commentConfig -}}
+        {{- if (eq $artalk.locale "") | and (eq $.Site.LanguageCode "en") -}}
+          {{- $artalk = dict "locale" "en-US" | merge $artalk -}}
+        {{- end -}}
+        {{- $commentConfig = dict "locale" ($artalk.locale | default $.Site.LanguageCode | default "auto") | dict "artalk" | merge $commentConfig -}}
+        {{- with .Site.Params.gravatar -}}
+          {{- $commentConfig = dict "mirror" .Host "default" .Style | dict "gravatar" | dict "artalk" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $artalk.server -}}
+          {{- $commentConfig = dict "server" . | dict "artalk" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $artalk.site -}}
+          {{- $commentConfig = dict "site" . | dict "artalk" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $artalk.placeholder -}}
+          {{- $commentConfig = dict "placeholder" . | dict "artalk" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $artalk.noComment -}}
+          {{- $commentConfig = dict "noComment" . | dict "artalk" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $artalk.sendBtn -}}
+          {{- $commentConfig = dict "sendBtn" . | dict "artalk" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $artalk.editorTravel -}}
+          {{- $commentConfig = dict "editorTravel" . | dict "artalk" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $artalk.flatMode -}}
+          {{- $commentConfig = dict "flatMode" . | dict "artalk" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $artalk.maxNesting -}}
+          {{- $commentConfig = dict "maxNesting" . | dict "artalk" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $artalk.lightgallery -}}
+          {{- $commentConfig = dict "lightgallery" . | dict "artalk" | merge $commentConfig -}}
+        {{- end -}}
+        <noscript>
+          Please enable JavaScript to view the comments powered by <a href="https://github.com/ArtalkJS/Artalk" rel="external nofollow noopener noreferrer">Artalk</a>.
+        </noscript>
       {{- end -}}
-      {{- $commentConfig = dict "locale" ($artalk.locale | default $.Site.LanguageCode | default "auto") | dict "artalk" | merge $commentConfig -}}
-      {{- with .Site.Params.gravatar -}}
-        {{- $commentConfig = dict "mirror" .Host "default" .Style | dict "gravatar" | dict "artalk" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $artalk.server -}}
-        {{- $commentConfig = dict "server" . | dict "artalk" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $artalk.site -}}
-        {{- $commentConfig = dict "site" . | dict "artalk" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $artalk.placeholder -}}
-        {{- $commentConfig = dict "placeholder" . | dict "artalk" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $artalk.noComment -}}
-        {{- $commentConfig = dict "noComment" . | dict "artalk" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $artalk.sendBtn -}}
-        {{- $commentConfig = dict "sendBtn" . | dict "artalk" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $artalk.editorTravel -}}
-        {{- $commentConfig = dict "editorTravel" . | dict "artalk" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $artalk.flatMode -}}
-        {{- $commentConfig = dict "flatMode" . | dict "artalk" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $artalk.maxNesting -}}
-        {{- $commentConfig = dict "maxNesting" . | dict "artalk" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $artalk.lightgallery -}}
-        {{- $commentConfig = dict "lightgallery" . | dict "artalk" | merge $commentConfig -}}
-      {{- end -}}
-      <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://github.com/ArtalkJS/Artalk" rel="external nofollow noopener noreferrer">Artalk</a>.
-      </noscript>
-    {{- end -}}
 
-    {{- /* Disqus Comment System */ -}}
-    {{- $disqus := $comment.disqus | default dict -}}
-    {{- if $disqus.enable -}}
-      <div id="disqus_thread" class="comment"></div>
-      {{- $source := printf "https://%v.disqus.com/embed.js" $disqus.shortname -}}
-      {{- dict "Source" $source "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
-      <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://disqus.com/?ref_noscript" rel="external nofollow noopener noreferrer">Disqus</a>.
-      </noscript>
-    {{- end -}}
+      {{- /* Disqus Comment System */ -}}
+      {{- $disqus := $comment.disqus | default dict -}}
+      {{- if $disqus.enable -}}
+        <div id="disqus_thread" class="comment"></div>
+        {{- $source := printf "https://%v.disqus.com/embed.js" $disqus.shortname -}}
+        {{- dict "Source" $source "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+        <noscript>
+          Please enable JavaScript to view the comments powered by <a href="https://disqus.com/?ref_noscript" rel="external nofollow noopener noreferrer">Disqus</a>.
+        </noscript>
+      {{- end -}}
 
-    {{- /* Gitalk Comment System */ -}}
-    {{- $gitalk := $comment.gitalk | default dict -}}
-    {{- if $gitalk.enable -}}
-      <div id="gitalk" class="comment"></div>
-      {{- $source := $cdn.gitalkCSS | default "lib/gitalk/gitalk.css" -}}
-      {{- dict "Source" $source "Minify" true "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/style.html" -}}
-      {{- $source := $cdn.gitalkJS | default "lib/gitalk/gitalk.min.js" -}}
-      {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
-      {{- $commentConfig = dict "id" .Date "title" .Title "clientID" $gitalk.clientId "clientSecret" $gitalk.clientSecret "repo" $gitalk.repo "owner" $gitalk.owner "admin" (slice $gitalk.owner) | dict "gitalk" | merge $commentConfig -}}
-      <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://github.com/gitalk/gitalk" rel="external nofollow noopener noreferrer">Gitalk</a>.
-      </noscript>
-    {{- end -}}
+      {{- /* Gitalk Comment System */ -}}
+      {{- $gitalk := $comment.gitalk | default dict -}}
+      {{- if $gitalk.enable -}}
+        <div id="gitalk" class="comment"></div>
+        {{- $source := $cdn.gitalkCSS | default "lib/gitalk/gitalk.css" -}}
+        {{- dict "Source" $source "Minify" true "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/style.html" -}}
+        {{- $source := $cdn.gitalkJS | default "lib/gitalk/gitalk.min.js" -}}
+        {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+        {{- $commentConfig = dict "id" .Date "title" .Title "clientID" $gitalk.clientId "clientSecret" $gitalk.clientSecret "repo" $gitalk.repo "owner" $gitalk.owner "admin" (slice $gitalk.owner) | dict "gitalk" | merge $commentConfig -}}
+        <noscript>
+          Please enable JavaScript to view the comments powered by <a href="https://github.com/gitalk/gitalk" rel="external nofollow noopener noreferrer">Gitalk</a>.
+        </noscript>
+      {{- end -}}
 
-    {{- /* Valine Comment System */ -}}
-    {{- $valine := $comment.valine | default dict -}}
-    {{- if $valine.enable -}}
-      <div id="valine" class="comment"></div>
-      {{- $options := dict "targetPath" "lib/valine/valine.min.css" -}}
-      {{- dict "Source" "lib/valine/valine.scss" "ToCSS" $options | dict "Scratch" .Scratch "Data" | partial "scratch/style.html" -}}
-      {{- $source := $cdn.valineJS | default "lib/valine/Valine.min.js" -}}
-      {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
-      {{- $commentConfig = dict "el" "#valine" "appId" $valine.appId "appKey" $valine.appKey "lang" ($valine.lang | default (T "valineLang")) "visitor" $valine.visitor "recordIP" $valine.recordIP "placeholder" ($valine.placeholder | default (T "valinePlaceholder")) "highlight" (ne $valine.highlight false) "enableQQ" $valine.enableQQ | dict "valine" | merge $commentConfig -}}
-      {{- with $valine.avatar -}}
-        {{- $commentConfig = dict "avatar" . | dict "valine" | merge $commentConfig -}}
+      {{- /* Valine Comment System */ -}}
+      {{- $valine := $comment.valine | default dict -}}
+      {{- if $valine.enable -}}
+        <div id="valine" class="comment"></div>
+        {{- $options := dict "targetPath" "lib/valine/valine.min.css" -}}
+        {{- dict "Source" "lib/valine/valine.scss" "ToCSS" $options | dict "Scratch" .Scratch "Data" | partial "scratch/style.html" -}}
+        {{- $source := $cdn.valineJS | default "lib/valine/Valine.min.js" -}}
+        {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+        {{- $commentConfig = dict "el" "#valine" "appId" $valine.appId "appKey" $valine.appKey "lang" ($valine.lang | default (T "valineLang")) "visitor" $valine.visitor "recordIP" $valine.recordIP "placeholder" ($valine.placeholder | default (T "valinePlaceholder")) "highlight" (ne $valine.highlight false) "enableQQ" $valine.enableQQ | dict "valine" | merge $commentConfig -}}
+        {{- with $valine.avatar -}}
+          {{- $commentConfig = dict "avatar" . | dict "valine" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $valine.meta -}}
+          {{- $commentConfig = dict "meta" . | dict "valine" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $valine.pageSize -}}
+          {{- $commentConfig = dict "pageSize" . | dict "valine" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $valine.serverURLs -}}
+          {{- $commentConfig = dict "serverURLs" . | dict "valine" | merge $commentConfig -}}
+        {{- end -}}
+        {{- $commentConfig = $valine.emoji | default "google.yml" | printf "lib/valine/emoji/%v" | resources.Get | transform.Unmarshal | dict "valine" | merge $commentConfig -}}
+        <noscript>
+          Please enable JavaScript to view the comments powered by <a href="https://valine.js.org/" rel="external nofollow noopener noreferrer">Valine</a>.
+        </noscript>
       {{- end -}}
-      {{- with $valine.meta -}}
-        {{- $commentConfig = dict "meta" . | dict "valine" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $valine.pageSize -}}
-        {{- $commentConfig = dict "pageSize" . | dict "valine" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $valine.serverURLs -}}
-        {{- $commentConfig = dict "serverURLs" . | dict "valine" | merge $commentConfig -}}
-      {{- end -}}
-      {{- $commentConfig = $valine.emoji | default "google.yml" | printf "lib/valine/emoji/%v" | resources.Get | transform.Unmarshal | dict "valine" | merge $commentConfig -}}
-      <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://valine.js.org/" rel="external nofollow noopener noreferrer">Valine</a>.
-      </noscript>
-    {{- end -}}
 
-    {{- /* Waline Comment System */ -}}
-    {{- /* see https://waline.js.org/reference/component.html */ -}}
-    {{- $waline := $comment.waline | default dict -}}
-    {{- if $waline.enable -}}
-      <div id="waline" class="comment"></div>
-      {{- $source := $cdn.walineCSS | default "lib/waline/waline.css" -}}
-      {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/style.html" -}}
-      {{- $source := $cdn.walineJS | default "lib/waline/waline.js" -}}
-      {{- dict "Source" $source "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
-      {{- $commentConfig = dict "el" "#waline" "serverURL" $waline.serverURL "lang" .Lang "dark" "body[data-theme='dark']" | dict "waline" | merge $commentConfig -}}
-      {{- $commentConfig = dict "copyright" true "imageUploader" false "highlighter" false "texRenderer" false "search" false | dict "waline" | merge $commentConfig -}}
-      {{- with $waline.pageview -}}
-        {{- $commentConfig = dict "pageview" . | dict "waline" | merge $commentConfig -}}
+      {{- /* Waline Comment System */ -}}
+      {{- /* see https://waline.js.org/reference/component.html */ -}}
+      {{- $waline := $comment.waline | default dict -}}
+      {{- if $waline.enable -}}
+        <div id="waline" class="comment"></div>
+        {{- $source := $cdn.walineCSS | default "lib/waline/waline.css" -}}
+        {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/style.html" -}}
+        {{- $source := $cdn.walineJS | default "lib/waline/waline.js" -}}
+        {{- dict "Source" $source "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+        {{- $commentConfig = dict "el" "#waline" "serverURL" $waline.serverURL "lang" .Lang "dark" "body[data-theme='dark']" | dict "waline" | merge $commentConfig -}}
+        {{- $commentConfig = dict "copyright" true "imageUploader" false "highlighter" false "texRenderer" false "search" false | dict "waline" | merge $commentConfig -}}
+        {{- with $waline.pageview -}}
+          {{- $commentConfig = dict "pageview" . | dict "waline" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $waline.emoji -}}
+          {{- $commentConfig = dict "emoji" . | dict "waline" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $waline.meta -}}
+          {{- $commentConfig = dict "meta" . | dict "waline" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $waline.requiredMeta -}}
+          {{- $commentConfig = dict "requiredMeta" . | dict "waline" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $waline.login -}}
+          {{- $commentConfig = dict "login" . | dict "waline" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $waline.wordLimit -}}
+          {{- $commentConfig = dict "wordLimit" . | dict "waline" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $waline.pageSize -}}
+          {{- $commentConfig = dict "pageSize" . | dict "waline" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $waline.imageUploader -}}
+          {{- $commentConfig = dict "imageUploader" . | dict "waline" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $waline.highlighter -}}
+          {{- $commentConfig = dict "highlighter" . | dict "waline" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $waline.comment -}}
+          {{- $commentConfig = dict "comment" . | dict "waline" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $waline.texRenderer -}}
+          {{- $commentConfig = dict "texRenderer" . | dict "waline" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $waline.search -}}
+          {{- $commentConfig = dict "search" . | dict "waline" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $waline.recaptchaV3Key -}}
+          {{- $commentConfig = dict "recaptchaV3Key" . | dict "waline" | merge $commentConfig -}}
+        {{- end -}}
+        <noscript>
+          Please enable JavaScript to view the comments powered by <a href="https://waline.js.org/" rel="external nofollow noopener noreferrer">Waline</a>.
+        </noscript>
       {{- end -}}
-      {{- with $waline.emoji -}}
-        {{- $commentConfig = dict "emoji" . | dict "waline" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $waline.meta -}}
-        {{- $commentConfig = dict "meta" . | dict "waline" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $waline.requiredMeta -}}
-        {{- $commentConfig = dict "requiredMeta" . | dict "waline" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $waline.login -}}
-        {{- $commentConfig = dict "login" . | dict "waline" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $waline.wordLimit -}}
-        {{- $commentConfig = dict "wordLimit" . | dict "waline" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $waline.pageSize -}}
-        {{- $commentConfig = dict "pageSize" . | dict "waline" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $waline.imageUploader -}}
-        {{- $commentConfig = dict "imageUploader" . | dict "waline" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $waline.highlighter -}}
-        {{- $commentConfig = dict "highlighter" . | dict "waline" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $waline.comment -}}
-        {{- $commentConfig = dict "comment" . | dict "waline" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $waline.texRenderer -}}
-        {{- $commentConfig = dict "texRenderer" . | dict "waline" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $waline.search -}}
-        {{- $commentConfig = dict "search" . | dict "waline" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $waline.recaptchaV3Key -}}
-        {{- $commentConfig = dict "recaptchaV3Key" . | dict "waline" | merge $commentConfig -}}
-      {{- end -}}
-      <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://waline.js.org/" rel="external nofollow noopener noreferrer">Waline</a>.
-      </noscript>
-    {{- end -}}
 
-    {{- /* Facebook Comment System */ -}}
-    {{- $facebook := $comment.facebook | default dict -}}
-    {{- if $facebook.enable -}}
-      <div id="fb-root" class="comment"></div>
-      <div
-        class="fb-comments"
-        data-href="{{ .Permalink }}"
-        data-width="{{ $facebook.width }}"
-        data-numposts="{{ $facebook.numPosts }}"
-      ></div>
-      {{- $source := printf "https://connect.facebook.net/%v/sdk.js#xfbml=1&version=v5.0&appId=%v&autoLogAppEvents=1" ($facebook.languageCode | default (T "facebookLanguageCode")) $facebook.appId -}}
-      {{- dict "Source" $source "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
-      <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://developers.facebook.com/docs/plugins/comments/" rel="external nofollow noopener noreferrer">Facebook</a>.
-      </noscript>
-    {{- end -}}
+      {{- /* Facebook Comment System */ -}}
+      {{- $facebook := $comment.facebook | default dict -}}
+      {{- if $facebook.enable -}}
+        <div id="fb-root" class="comment"></div>
+        <div
+          class="fb-comments"
+          data-href="{{ .Permalink }}"
+          data-width="{{ $facebook.width }}"
+          data-numposts="{{ $facebook.numPosts }}"
+        ></div>
+        {{- $source := printf "https://connect.facebook.net/%v/sdk.js#xfbml=1&version=v5.0&appId=%v&autoLogAppEvents=1" ($facebook.languageCode | default (T "facebookLanguageCode")) $facebook.appId -}}
+        {{- dict "Source" $source "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+        <noscript>
+          Please enable JavaScript to view the comments powered by <a href="https://developers.facebook.com/docs/plugins/comments/" rel="external nofollow noopener noreferrer">Facebook</a>.
+        </noscript>
+      {{- end -}}
 
-    {{- /* Telegram Comments System */ -}}
-    {{- $telegram := $comment.telegram | default dict -}}
-    {{- if $telegram.enable -}}
-      <div id="telegram-comments" class="comment"></div>
-      {{- $attr := printf `data-comments-app-website="%v"` $telegram.siteID -}}
-      {{- $attr = printf `%v data-limit="%v"` $attr ($telegram.limit | default 5) -}}
-      {{- with $telegram.height -}}
-        {{- $attr = printf `%v data-height="%v"` $attr . -}}
+      {{- /* Telegram Comments System */ -}}
+      {{- $telegram := $comment.telegram | default dict -}}
+      {{- if $telegram.enable -}}
+        <div id="telegram-comments" class="comment"></div>
+        {{- $attr := printf `data-comments-app-website="%v"` $telegram.siteID -}}
+        {{- $attr = printf `%v data-limit="%v"` $attr ($telegram.limit | default 5) -}}
+        {{- with $telegram.height -}}
+          {{- $attr = printf `%v data-height="%v"` $attr . -}}
+        {{- end -}}
+        {{- with $telegram.color -}}
+          {{- $attr = printf `%v data-color="%v"` $attr . -}}
+        {{- end -}}
+        {{- if $telegram.colorful -}}
+          {{- $attr = printf `%v data-colorful="1"` $attr -}}
+        {{- end -}}
+        {{- if $telegram.dislikes -}}
+          {{- $attr = printf `%v data-dislikes="1"` $attr -}}
+        {{- end -}}
+        {{- if $telegram.outlined -}}
+          {{- $attr = printf `%v data-outlined="1"` $attr -}}
+        {{- end -}}
+        {{- dict "Source" "https://comments.app/js/widget.js?2" "Defer" true "Attr" $attr | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+        <noscript>
+          Please enable JavaScript to view the comments powered by <a href="https://comments.app/" rel="external nofollow noopener noreferrer">Telegram Comments</a>.
+        </noscript>
       {{- end -}}
-      {{- with $telegram.color -}}
-        {{- $attr = printf `%v data-color="%v"` $attr . -}}
-      {{- end -}}
-      {{- if $telegram.colorful -}}
-        {{- $attr = printf `%v data-colorful="1"` $attr -}}
-      {{- end -}}
-      {{- if $telegram.dislikes -}}
-        {{- $attr = printf `%v data-dislikes="1"` $attr -}}
-      {{- end -}}
-      {{- if $telegram.outlined -}}
-        {{- $attr = printf `%v data-outlined="1"` $attr -}}
-      {{- end -}}
-      {{- dict "Source" "https://comments.app/js/widget.js?2" "Defer" true "Attr" $attr | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
-      <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://comments.app/" rel="external nofollow noopener noreferrer">Telegram Comments</a>.
-      </noscript>
-    {{- end -}}
 
-    {{- /* Commento Comment System */ -}}
-    {{- $commento := $comment.commento | default dict -}}
-    {{- if $commento.enable -}}
-      <div id="commento" class="comment"></div>
-      {{- dict "Source" "https://cdn.commento.io/js/commento.js" "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
-      <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://commento.io/" rel="external nofollow noopener noreferrer">Commento</a>.
-      </noscript>
-    {{- end -}}
+      {{- /* Commento Comment System */ -}}
+      {{- $commento := $comment.commento | default dict -}}
+      {{- if $commento.enable -}}
+        <div id="commento" class="comment"></div>
+        {{- dict "Source" "https://cdn.commento.io/js/commento.js" "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+        <noscript>
+          Please enable JavaScript to view the comments powered by <a href="https://commento.io/" rel="external nofollow noopener noreferrer">Commento</a>.
+        </noscript>
+      {{- end -}}
 
-    {{- /* Utterances Comment System */ -}}
-    {{- $utterances := $comment.utterances | default dict -}}
-    {{- if $utterances.enable -}}
-      <div id="utterances" class="comment"></div>
-      {{- $commentConfig = dict "repo" $utterances.repo | dict "utterances" | merge $commentConfig -}}
-      {{- $commentConfig = $utterances.issueTerm | default "pathname" | dict "issueTerm" | dict "utterances" | merge $commentConfig -}}
-      {{- $commentConfig = dict "label" $utterances.label | dict "utterances" | merge $commentConfig -}}
-      {{- $commentConfig = $utterances.lightTheme | default "github-light" | dict "lightTheme" | dict "utterances" | merge $commentConfig -}}
-      {{- $commentConfig = $utterances.darkTheme | default "github-dark" | dict "darkTheme" | dict "utterances" | merge $commentConfig -}}
-      <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://utteranc.es/" rel="external nofollow noopener noreferrer">Utterances</a>.
-      </noscript>
-    {{- end -}}
+      {{- /* Utterances Comment System */ -}}
+      {{- $utterances := $comment.utterances | default dict -}}
+      {{- if $utterances.enable -}}
+        <div id="utterances" class="comment"></div>
+        {{- $commentConfig = dict "repo" $utterances.repo | dict "utterances" | merge $commentConfig -}}
+        {{- $commentConfig = $utterances.issueTerm | default "pathname" | dict "issueTerm" | dict "utterances" | merge $commentConfig -}}
+        {{- $commentConfig = dict "label" $utterances.label | dict "utterances" | merge $commentConfig -}}
+        {{- $commentConfig = $utterances.lightTheme | default "github-light" | dict "lightTheme" | dict "utterances" | merge $commentConfig -}}
+        {{- $commentConfig = $utterances.darkTheme | default "github-dark" | dict "darkTheme" | dict "utterances" | merge $commentConfig -}}
+        <noscript>
+          Please enable JavaScript to view the comments powered by <a href="https://utteranc.es/" rel="external nofollow noopener noreferrer">Utterances</a>.
+        </noscript>
+      {{- end -}}
 
-    {{- /* Twikoo Comment System */ -}}
-    {{- $twikoo := $comment.twikoo | default dict -}}
-    {{- if $twikoo.enable -}}
-      <div id="twikoo"></div>
-      {{- $source := $cdn.twikooJS | default "lib/twikoo/twikoo.all.min.js" -}}
-      {{- dict "Source" $source "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
-      {{- $commentConfig = dict "el" "#twikoo" "envId" $twikoo.envId "lang" .Lang | dict "twikoo" | merge $commentConfig -}}
-      {{- with $twikoo.region -}}
-        {{- $commentConfig = dict "region" . | dict "twikoo" | merge $commentConfig -}}
+      {{- /* Twikoo Comment System */ -}}
+      {{- $twikoo := $comment.twikoo | default dict -}}
+      {{- if $twikoo.enable -}}
+        <div id="twikoo"></div>
+        {{- $source := $cdn.twikooJS | default "lib/twikoo/twikoo.all.min.js" -}}
+        {{- dict "Source" $source "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+        {{- $commentConfig = dict "el" "#twikoo" "envId" $twikoo.envId "lang" .Lang | dict "twikoo" | merge $commentConfig -}}
+        {{- with $twikoo.region -}}
+          {{- $commentConfig = dict "region" . | dict "twikoo" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $twikoo.path -}}
+          {{- $commentConfig = dict "path" . | dict "twikoo" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $twikoo.commentCount -}}
+          {{- $commentConfig = dict "commentCount" . | dict "twikoo" | merge $commentConfig -}}
+        {{- end -}}
+        {{- with $twikoo.lightgallery -}}
+          {{- $commentConfig = dict "lightgallery" . | dict "twikoo" | merge $commentConfig -}}
+        {{- end -}}
+        <noscript>
+          Please enable JavaScript to view the comments powered by <a href="https://twikoo.js.org/" rel="external nofollow noopener noreferrer">Twikoo</a>.
+        </noscript>
       {{- end -}}
-      {{- with $twikoo.path -}}
-        {{- $commentConfig = dict "path" . | dict "twikoo" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $twikoo.commentCount -}}
-        {{- $commentConfig = dict "commentCount" . | dict "twikoo" | merge $commentConfig -}}
-      {{- end -}}
-      {{- with $twikoo.lightgallery -}}
-        {{- $commentConfig = dict "lightgallery" . | dict "twikoo" | merge $commentConfig -}}
-      {{- end -}}
-      <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://twikoo.js.org/" rel="external nofollow noopener noreferrer">Twikoo</a>.
-      </noscript>
-    {{- end -}}
 
-    {{- /* Giscus Comment System */ -}}
-    {{- $giscus := $comment.giscus | default dict -}}
-    {{- if $giscus.enable -}}
-      {{- with $giscus -}}
-        {{- $commentConfig = .lightTheme | default "light" | dict "lightTheme" | dict "giscus" | merge $commentConfig -}}
-        {{- $commentConfig = .darkTheme | default "dark" | dict "darkTheme" | dict "giscus" | merge $commentConfig -}}
-        <div id="giscus">
-          <script
-            src="https://giscus.app/client.js"
-            data-repo="{{ .Repo }}"
-            data-repo-id="{{ .RepoId }}"
-            data-category="{{ .Category }}"
-            data-category-id="{{ .CategoryId }}"
-            data-mapping="{{ .Mapping }}"
-            {{ if .Term }}data-term="{{ .Term }}"{{ end }}
-            data-theme="preferred_color_scheme"
-            data-reactions-enabled="{{ .ReactionsEnabled }}"
-            data-emit-metadata="{{ .EmitMetadata }}"
-            data-input-position="{{ .InputPosition }}"
-            data-lang="{{ $.Site.LanguageCode }}"
-            {{ if ne .LazyLoad false }}data-loading="lazy"{{ end }}
-            crossorigin="anonymous"
-            async
-            defer
-          ></script>
-          <noscript>
-            Please enable JavaScript to view the comments powered by <a href="https://giscus.app/" rel="external nofollow noopener noreferrer">giscus</a>.
-          </noscript>
-        </div>
+      {{- /* Giscus Comment System */ -}}
+      {{- $giscus := $comment.giscus | default dict -}}
+      {{- if $giscus.enable -}}
+        {{- with $giscus -}}
+          {{- $commentConfig = .lightTheme | default "light" | dict "lightTheme" | dict "giscus" | merge $commentConfig -}}
+          {{- $commentConfig = .darkTheme | default "dark" | dict "darkTheme" | dict "giscus" | merge $commentConfig -}}
+          <div id="giscus">
+            <script
+              src="https://giscus.app/client.js"
+              data-repo="{{ .Repo }}"
+              data-repo-id="{{ .RepoId }}"
+              data-category="{{ .Category }}"
+              data-category-id="{{ .CategoryId }}"
+              data-mapping="{{ .Mapping }}"
+              {{ if .Term }}data-term="{{ .Term }}"{{ end }}
+              data-theme="preferred_color_scheme"
+              data-reactions-enabled="{{ .ReactionsEnabled }}"
+              data-emit-metadata="{{ .EmitMetadata }}"
+              data-input-position="{{ .InputPosition }}"
+              data-lang="{{ $.Site.LanguageCode }}"
+              {{ if ne .LazyLoad false }}data-loading="lazy"{{ end }}
+              crossorigin="anonymous"
+              async
+              defer
+            ></script>
+            <noscript>
+              Please enable JavaScript to view the comments powered by <a href="https://giscus.app/" rel="external nofollow noopener noreferrer">giscus</a>.
+            </noscript>
+          </div>
+        {{- end -}}
       {{- end -}}
-    {{- end -}}
-  </div>
+    </div>
+  {{- end -}}
 {{- end -}}
 
 {{- dict "comment" $commentConfig | dict "config" | merge (.Scratch.Get "this") | .Scratch.Set "this" -}}


### PR DESCRIPTION
For each single page for which you want to deactivate the comments, add the following property to your front matter:
`noComment: true`