### PR TITLE
fix: discordinvite typo

### DIFF
--- a/assets/data/social.yml
+++ b/assets/data/social.yml
@@ -573,7 +573,7 @@ discord:
     Class: fa-brands fa-discord fa-fw
 
 # 073: Discord Server Invite Link
-discordInvite:
+discordinvite:
   Weight: 73
   Prefix: https://discord.gg/
   Title: Discord

--- a/config.toml
+++ b/config.toml
@@ -810,7 +810,8 @@
       type = "vConsole"
 
 # -------------------------------------------------------------------------------------
-# Hugo version required
+# Modules Configure
+# See: https://gohugo.io/hugo-modules/configuration/#module-config-imports
 # -------------------------------------------------------------------------------------
 [module]
   [module.hugoVersion]

--- a/config.toml
+++ b/config.toml
@@ -329,7 +329,7 @@
     Diaspora = ""
     CSDN = ""
     Discord = ""
-    DiscordInvite = ""
+    Discordinvite = ""
     Lichess = ""
     Pleroma = ""
     Kaggle = ""


### PR DESCRIPTION
Hello,
It's seems DiscordInvite not working due to the I in uppercase.
I see on `profile.html` a lower, maybe it's the root cause.

Thanks