### PR TITLE
fix anchor link positioning

### DIFF
--- a/layouts/partials/plugin/image.html
+++ b/layouts/partials/plugin/image.html
@@ -10,6 +10,8 @@
     {{- $height = $height | default .Height -}}
   {{- end -}}
 {{- end -}}
+{{- /* lazysize.js causes inaccurate positioning for anchor links, don't activate it if no alternatives */ -}}
+{{- $responsive := ne (or .SrcSmall .SrcLarge) nil -}}
 
 {{- $style := "" -}}
 {{- with $width -}}
@@ -36,11 +38,15 @@
 {{- if .Linked -}}
   <a class="lightgallery" href="{{ $large | safeURL }}" data-thumbnail="{{ $small | safeURL }}"{{ with $caption }} data-sub-html="<h2>{{ . }}</h2>{{ with $.Title }}<p>{{ . }}</p>{{ end }}"{{ end }}{{ with .Rel }} rel="{{ . }}"{{ end }}>
     <img
-      class="lazyload{{ with .Class }} {{ . }}{{ end }}"
+      class="{{ if $responsive }}lazyload{{ end }}{{ with .Class }} {{ . }}{{ end }}"
+      {{ if $responsive }}
       src="{{ $loading.RelPermalink }}"
       data-src="{{ $src | safeURL }}"
       data-srcset="{{ $small | safeURL }}, {{ $src | safeURL }} 1.5x, {{ $large | safeURL }} 2x"
       data-sizes="auto"
+      {{ else }}
+      src="{{ $src | safeURL }}"
+      {{ end }}
       alt="{{ $alt }}"
       title="{{ .Title | default $alt }}"
       {{- with $width }} width="{{ . }}"{{- end -}}
@@ -51,11 +57,15 @@
   </a>
 {{- else -}}
   <img
-    class="lazyload{{ with .Class }} {{ . }}{{ end }}"
+    class="{{ if $responsive }}lazyload{{ end }}{{ with .Class }} {{ . }}{{ end }}"
+    {{ if $responsive }}
     src="{{ $loading.RelPermalink }}"
     data-src="{{ $src | safeURL }}"
     data-srcset="{{ $small | safeURL }}, {{ $src | safeURL }} 1.5x, {{ $large | safeURL }} 2x"
     data-sizes="auto"
+    {{ else }}
+    src="{{ $src | safeURL }}"
+    {{ end }}
     alt="{{ $alt }}"
     title="{{ .Title | default $alt }}"
     {{- with $width }} width="{{ . }}"{{- end -}}


### PR DESCRIPTION
Suppose we have an article:

```markdown
# header1
any text...
![](img1.png)

# header2
any text...
![](img2.png)

# header3
any text...
![](img3.png)
```

Now we want to visitor the anchor link: `See also [header3](https://host/page#header3)`, which is very common in a document site.

Because of the `lazysize.js`, the Browser cannot detect the real sizes of `img1`, `img2`:

1. The Browser scroll to `#header3`
1. `lazysize.js` runs, updates `img1`, `img2`
1. Updated `img1`, `img2` push the scroll position, users can not find the expected `#header3` title.

Standard MarkDown syntax of image supports only one image, which means we don't need `lazysize.js` in most cases, this is what this PR does to fix anchor link positioning.