### PR TITLE
Use dateFormat function to render localized dates

### DIFF
--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -42,7 +42,7 @@
           <article class="archive-item">
             <a href="{{ .RelPermalink }}" class="archive-item-link">{{- .Title -}}</a>
             <span class="archive-item-date" title='{{ "2006-01-02 15:04:05" | .Date.Format }}'>
-              {{- $.Site.Params.section.dateFormat | default "01-02" | .Date.Format -}}
+              {{- .Date | dateFormat ($.Site.Params.section.dateFormat | default "01-02") -}}
             </span>
           </article>
         {{- end -}}

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -34,7 +34,7 @@
   <div class="post-meta">
     {{- partial "single/post-author.html" . -}}
 
-    {{- with .Site.Params.dateFormat | default "2006-01-02" | .PublishDate.Format -}}
+    {{- with .PublishDate | dateFormat (.Site.Params.dateFormat | default "2006-01-02") -}}
       &nbsp;<span class="post-publish" title='{{ "2006-01-02 15:04:05" | $.PublishDate.Format }}'>
         {{- printf `<time datetime="%v">%v</time>` . . | dict "Date" | T "single.publishedOnDate" | safeHTML -}}
       </span>

--- a/layouts/partials/recently-updated.html
+++ b/layouts/partials/recently-updated.html
@@ -14,7 +14,7 @@
         <article class="archive-item">
           <a href="{{ .RelPermalink }}" class="archive-item-link">{{- .Title -}}</a>
           <span class="archive-item-date" title='{{ "2006-01-02 15:04:05" | .Lastmod.Format }}'>
-            {{- with .Site.Params.section.dateformat | default "01-02" | .Lastmod.Format -}}
+            {{- with .Lastmod | dateFormat (.Site.Params.section.dateformat | default "01-02") -}}
               {{- dict "Date" . | T "single.updatedOnDate" -}}
             {{- end -}}
           </span>

--- a/layouts/partials/single/expiration-reminder.html
+++ b/layouts/partials/single/expiration-reminder.html
@@ -20,7 +20,7 @@
       </div>
       <div class="details-content">
         <div class="admonition-content">
-          {{- with .Site.Params.dateformat | default "2006-01-02" | $updateTime.Format -}}
+          {{- with $updateTime | dateFormat (.Site.Params.dateformat | default "2006-01-02") -}}
             {{- dict "Date" . | T "single.expirationReminder" -}}
           {{- end -}}
         </div>

--- a/layouts/partials/single/footer.html
+++ b/layouts/partials/single/footer.html
@@ -6,7 +6,7 @@
     <div class="post-info-line">
       <div class="post-info-mod">
         <span title="{{ dict "Date" ("2006-01-02 15:04:05" | .Lastmod.Format) | T "single.updatedOnDate" }}">
-          {{- with .Site.Params.dateformat | default "2006-01-02" | .Lastmod.Format -}}
+          {{- with .Lastmod | dateFormat (.Site.Params.dateformat | default "2006-01-02") -}}
             {{- dict "Date" . | T "single.updatedOnDate" -}}&nbsp;
             {{- if $gitRepo -}}
               {{- with $.GitInfo -}}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -61,13 +61,13 @@
         {{- end -}}
       </div>
       <div class="post-meta-line">
-        {{- with .Site.Params.dateformat | default "2006-01-02" | .PublishDate.Format -}}
+        {{- with .PublishDate | dateFormat (.Site.Params.dateformat | default "2006-01-02") -}}
           <span title="{{ dict "Date" ("2006-01-02 15:04:05" | $.PublishDate.Format) | T "single.publishedOnDate" }}">
             {{- dict "Class" "fa-regular fa-calendar-alt fa-fw me-1" | partial "plugin/icon.html" -}}
             {{- printf `<time datetime="%v">%v</time>` . . | safeHTML -}}
           </span>&nbsp;
         {{- end -}}
-        {{- with .Site.Params.dateformat | default "2006-01-02" | .Lastmod.Format -}}
+        {{- with .Lastmod | dateFormat (.Site.Params.dateformat | default "2006-01-02") -}}
           <span title="{{ dict "Date" ("2006-01-02 15:04:05" | $.Lastmod.Format) | T "single.updatedOnDate" }}">
             {{- dict "Class" "fa-regular fa-edit fa-fw me-1" | partial "plugin/icon.html" -}}
             {{- printf `<time datetime="%v">%v</time>` . . | safeHTML -}}


### PR DESCRIPTION
This PR fixes the date not being rendered honoring the content localization.

## 🪲 Found bug
The dates were rendered using the [.Format](https://gohugo.io/functions/format/) function which does not follow the content localization. 
Example: the date `2023-06-07` was rendered as "7 June 2023" inside an **Italian content**.

## ✅ Applied fix
The fix replaces the `.Format` function with the [dateFormat](https://gohugo.io/functions/dateformat/) one, which respects the page localization. Going on with the example above, the Italian content now renders the same date as "7 giugno 2023" which is the expected output.