### PR TITLE
Add option to cache remote image locally

### DIFF
--- a/layouts/partials/init/index.html
+++ b/layouts/partials/init/index.html
@@ -1,4 +1,4 @@
-{{- .Scratch.Set "version" "v0.2.18-lts.2" -}}
+{{- .Scratch.Set "version" "v0.2.18-lts.3-RC" -}}
 {{- .Scratch.Set "params" (.Params | merge .Site.Params.page) -}}
 {{- .Scratch.Set "this" dict -}}
 

--- a/layouts/partials/plugin/image.html
+++ b/layouts/partials/plugin/image.html
@@ -37,7 +37,7 @@
 {{- if .Linked -}}
   <a class="lightgallery" href="{{ $large | safeURL }}" data-thumbnail="{{ $small | safeURL }}"{{ with $caption }} data-sub-html="<h2>{{ . }}</h2>{{ with $.Title }}<p>{{ . }}</p>{{ end }}"{{ end }}{{ with .Rel }} rel="{{ . }}"{{ end }}>
 {{- end -}}
-<img loading="{{ $loading }}" src="{{ .Src | safeURL }}" srcset="{{ $small | safeURL }}, {{ .Src | safeURL }} 1.5x, {{ $large | safeURL }} 2x" sizes="auto"
+<img loading="{{ $loading }}" src="{{ $src | safeURL }}" srcset="{{ $small | safeURL }}, {{ $src | safeURL }} 1.5x, {{ $large | safeURL }} 2x" sizes="auto"
   {{- if eq $loading "eager" }} title="{{ .Title | default $alt }}" alt="{{ $alt }}"
   {{- else }} data-title="{{ .Title | default $alt }}" data-alt="{{ $alt }}"{{- end -}}
   {{- with $width }} width="{{ . }}"{{- end -}}


### PR DESCRIPTION
## Why

With the GetRemote function provided by hugo and some robust matching methods, FixIt now can cache remote images locally. This feature mainly focus on adding height and width to remote images in markdown to prevent [layout shifts](https://web.dev/browser-level-image-lazy-loading/#images-should-include-dimension-attributes), caching these images locally is more like an added benefit. The advantages and disadvantages of this feature are relatively obvious, so it will be offered as an option(off by default) to the user.

Fixes #348 

## Pros

- Automatically add width and height to images on remote sources, avoid the occurrence of layout shift.
- Improve the consistency of the page loading experience.
- Lots of features can be achieved with the images cached locally, such as letting hugo crop different size images for [responsive loading](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images), or even better, convert these images to modern webp format while resizing.

## Cons

- More local disk space required.
- Site build time will be affected by th loading speed of remote images.

## Reference

- https://github.com/HEIGE-PCloud/DoIt/pull/860