### PR TITLE
Add related content support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FixIt Theme | Hugo
 
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/hugo-fixit/FixIt?style=flat)](https://github.com/hugo-fixit/FixIt/releases)
-[![Hugo](https://img.shields.io/badge/Hugo-%5E0.110.0-ff4088?style=flat&logo=hugo)](https://gohugo.io/)
+[![Hugo](https://img.shields.io/badge/Hugo-%5E0.111.0-ff4088?style=flat&logo=hugo)](https://gohugo.io/)
 [![License](https://img.shields.io/github/license/hugo-fixit/FixIt?style=flat)](/LICENSE)
 
 👉 English README | [简体中文说明](README.zh-cn.md)

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -1,7 +1,7 @@
 # FixIt 主题 | Hugo
 
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/hugo-fixit/FixIt?style=flat)](https://github.com/hugo-fixit/FixIt/releases)
-[![Hugo](https://img.shields.io/badge/Hugo-%5E0.110.0-ff4088?style=flat&logo=hugo)](https://gohugo.io/)
+[![Hugo](https://img.shields.io/badge/Hugo-%5E0.111.0-ff4088?style=flat&logo=hugo)](https://gohugo.io/)
 [![License](https://img.shields.io/github/license/hugo-fixit/FixIt?style=flat)](/LICENSE)
 
 👉 [English README](README.md) | 简体中文说明

--- a/hugo.toml
+++ b/hugo.toml
@@ -699,6 +699,11 @@ enableEmoji = true
         name = ""
         logoUrl = ""
 
+    # FixIt 0.3.0 | NEW Related content config
+    [params.page.related]
+      enable = false
+      count = 5
+
   # FixIt 0.2.5 | NEW TypeIt config
   [params.typeit]
     # typing speed between each step (measured in milliseconds)
@@ -878,6 +883,45 @@ enableEmoji = true
       type = "vConsole"
 
 # -------------------------------------------------------------------------------------
+# Related content Configuration
+# See: https://gohugo.io/content-management/related/
+# -------------------------------------------------------------------------------------
+
+[related]
+  includeNewer = false
+  threshold = 80
+  toLower = false
+[[related.indices]]
+  applyFilter = false
+  cardinalityThreshold = 0
+  name = 'keywords'
+  pattern = ''
+  toLower = false
+  type = 'basic'
+  weight = 100
+[[related.indices]]
+  applyFilter = false
+  cardinalityThreshold = 0
+  name = 'date'
+  pattern = ''
+  toLower = false
+  type = 'basic'
+  weight = 10
+[[related.indices]]
+  applyFilter = false
+  cardinalityThreshold = 0
+  name = 'tags'
+  pattern = ''
+  toLower = false
+  type = 'basic'
+  weight = 80
+[[related.indices]]
+  applyFilter = false
+  name = 'fragmentrefs'
+  type = 'fragments'
+  weight = 80
+
+# -------------------------------------------------------------------------------------
 # Modules Configuration
 # See: https://gohugo.io/hugo-modules/configuration/#module-config-imports
 # -------------------------------------------------------------------------------------
@@ -885,7 +929,7 @@ enableEmoji = true
 [module]
   [module.hugoVersion]
     extended = true
-    min = "0.110.0"
+    min = "0.111.0"
 
 # -------------------------------------------------------------------------------------
 # Markup related configuration in Hugo
@@ -1000,7 +1044,6 @@ enableEmoji = true
 # -------------------------------------------------------------------------------------
 
 [taxonomies]
-  # series = "series"
   category = "categories"
   tag = "tags"
-  collections = "collections"
+  collection = "collections"

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -120,6 +120,7 @@ encryptedAbstract = ""
 encryptedMessage = ""
 password = "Passwort"
 encryptyAgain = ""
+relatedContent = "Ähnliche Inhalte"
 
 [single.includedIn]
 categories = "enthalten in {{ .Categories }}"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -119,6 +119,7 @@ encryptedAbstract = "This article has been encrypted, so its raw content is invi
 encryptedMessage = "Please enter the password"
 password = "Password"
 encryptyAgain = "Encrypt again"
+relatedContent = "Related Content"
 
 [single.includedIn]
 categories = "included in {{ .Categories }}"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -120,6 +120,7 @@ encryptedAbstract = ""
 encryptedMessage = ""
 password = "Contraseña"
 encryptyAgain = ""
+relatedContent = "Contenido relacionado"
 
 [single.includedIn]
 categories = "incluido en {{ .Categories }}"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -119,6 +119,7 @@ encryptedAbstract = "Cet article a été chiffré, son contenu n'est donc pas li
 encryptedMessage = "Entrer le mot de passe"
 password = "Mot de passe"
 encryptyAgain = "Chiffrer à nouveau"
+relatedContent = "Contenu lié"
 
 [single.includedIn]
 categories = "inclus dans {{ .Categories }}"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -120,6 +120,7 @@ encryptedAbstract = ""
 encryptedMessage = ""
 password = "Password"
 encryptyAgain = ""
+relatedContent = "Contenuti correlati"
 
 [single.includedIn]
 categories = "incluso in {{ .Categories }}"

--- a/i18n/pl.toml
+++ b/i18n/pl.toml
@@ -120,6 +120,7 @@ encryptedAbstract = ""
 encryptedMessage = ""
 password = "Hasło"
 encryptyAgain = ""
+relatedContent = "Powiązane treści"
 
 [single.includedIn]
 categories = "zawarty w {{ .Categories }}"

--- a/i18n/pt-BR.toml
+++ b/i18n/pt-BR.toml
@@ -120,6 +120,7 @@ encryptedAbstract = ""
 encryptedMessage = ""
 password = "Contrasinha"
 encryptyAgain = ""
+relatedContent = "Conteúdo relacionado"
 
 [single.includedIn]
 categories = "incluido em {{ .Categories }}"

--- a/i18n/ro.toml
+++ b/i18n/ro.toml
@@ -120,6 +120,7 @@ encryptedAbstract = ""
 encryptedMessage = ""
 password = "Parolă"
 encryptyAgain = ""
+relatedContent = "Conținut înrudit"
 
 [single.includedIn]
 categories = "inclus în {{ .Categories }}"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -120,6 +120,7 @@ encryptedAbstract = ""
 encryptedMessage = ""
 password = "арготизм"
 encryptyAgain = ""
+relatedContent = "Связанный контент"
 
 [single.includedIn]
 categories = "включен в {{ .Categories }}"

--- a/i18n/sr.toml
+++ b/i18n/sr.toml
@@ -120,6 +120,7 @@ encryptedAbstract = ""
 encryptedMessage = ""
 password = "Паролица"
 encryptyAgain = ""
+relatedContent = "Повезани садржај"
 
 [single.includedIn]
 categories = "укључено {{ .Categories }}"

--- a/i18n/vi.toml
+++ b/i18n/vi.toml
@@ -119,6 +119,7 @@ encryptedAbstract = ""
 encryptedMessage = ""
 password = "Mật khẩu"
 encryptyAgain = ""
+relatedContent = "Nội dung liên quan"
 
 [single.includedIn]
 categories = "trong {{ .Categories }}"

--- a/i18n/zh-CN.toml
+++ b/i18n/zh-CN.toml
@@ -118,6 +118,7 @@ encryptedAbstract = "本文已加密，因此其原始内容不可见！"
 encryptedMessage = "请输入密码"
 password = "密码"
 encryptyAgain = "重新加密"
+relatedContent = "相关内容"
 
 [single.includedIn]
 categories = "收录于 {{ .Categories }}"

--- a/i18n/zh-TW.toml
+++ b/i18n/zh-TW.toml
@@ -118,6 +118,7 @@ encryptedAbstract = "本文已加密，囙此其原始內容不可見！"
 encryptedMessage = "請輸入密碼"
 password = "密碼"
 encryptyAgain = "重新加密"
+relatedContent = "相關內容"
 
 [single.includedIn]
 categories = "收錄於 {{ .Categories }}"

--- a/layouts/partials/single/related.html
+++ b/layouts/partials/single/related.html
@@ -1,0 +1,27 @@
+{{- /* Related Content */ -}}
+{{- /* https://gohugo.io/content-management/related/ */ -}}
+{{- $params := .Scratch.Get "params" -}}
+
+{{- if $params.related.enable -}}
+  {{- $related := .Site.RegularPages.Related . | first ($params.related.count | default 5) -}}
+  {{- with $related -}}
+    <h2 id="see-also">{{ T "single.relatedContent" }}</h2>
+    <ul>
+      {{- range $i, $p := . -}}
+        <li>
+          <a href="{{ .RelPermalink }}" title="{{ .LinkTitle }}">{{ .LinkTitle }}</a>
+          {{- with .HeadingsFiltered -}}
+            <ul>
+              {{- range . -}}
+                {{- $link := printf "%s#%s" $p.RelPermalink .ID | safeURL -}}
+                <li>
+                  <a href="{{ $link }}" title="{{ .Title }}">{{ .Title }}</a>
+                </li>
+              {{- end -}}
+            </ul>
+          {{- end -}}
+        </li>
+      {{- end -}}
+    </ul>
+  {{- end -}}
+{{- end -}}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -179,6 +179,9 @@
       {{- end -}}
     </div>
 
+    {{- /* Related Content */ -}}
+    {{- partial "single/related.html" . -}}
+
     {{- /* Reward before Footer */ -}}
     {{- $reward := .Scratch.Get "reward" -}}
     {{- if eq $reward.position "before" -}}

--- a/theme.toml
+++ b/theme.toml
@@ -7,7 +7,7 @@ licenselink = "https://github.com/hugo-fixit/FixIt/blob/master/LICENSE"
 description = "A Clean, Elegant but Advanced Hugo Theme for Hugo."
 homepage = "https://github.com/hugo-fixit/FixIt"
 demosite = "https://fixit.lruihao.cn"
-min_version = "0.110.0"
+min_version = "0.111.0"
 
 tags = [
   "blog",


### PR DESCRIPTION
Open `params.page.related.enable` to enable this feature.

https://github.com/hugo-fixit/FixIt/blob/e4367587f1f594f236270790ca7e0b818e57ce6a/hugo.toml#L702-L705

- https://gohugo.io/content-management/related/

resolved #227 