### PR TITLE
:sparkles: Feat: add archives page template

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -423,15 +423,23 @@ enableEmoji = true
       visitor = 0
       beian = 0
 
-  # Section (all posts) page config
+  # FixIt 0.3.0 | NEW Archives page config (all pages of posts type)
+  [params.archives]
+    # special amount of posts in archives page
+    paginate = 20
+    # date format (month and day)
+    dateFormat = "01-02"
+
+  # Section page config (all pages in section)
   [params.section]
-    # special amount of posts in each section page
+    # special amount of pages in each section page
     paginate = 20
     # date format (month and day)
     dateFormat = "01-02"
     # amount of RSS pages
     rss = 10
-    # FixIt 0.2.13 | NEW recently updated posts settings
+    # FixIt 0.2.13 | NEW recently updated pages config
+    # TODO refactor to support archives, section, taxonomy and term
     [params.section.recentlyUpdated]
       enable = false
       rss = false

--- a/hugo.toml
+++ b/hugo.toml
@@ -225,6 +225,14 @@ enableEmoji = true
     mediaType = "text/plain"
     isPlainText = true
     isHTML = false
+  # FixIt 0.3.0 | NEW Options to make output /archives/index.html file
+  [archives]
+    path = "archives"
+    baseName = "index"
+    mediaType = "text/html"
+    isPlainText = false
+    isHTML = true
+    permalinkable = true
 
 # -------------------------------------------------------------------------------------
 # Customizing Output Formats
@@ -232,7 +240,7 @@ enableEmoji = true
 # -------------------------------------------------------------------------------------
 
 [outputs]
-  home = ["HTML", "RSS", "JSON", "BaiduUrls"]
+  home = ["HTML", "RSS", "JSON", "BaiduUrls", "archives"]
   page = ["HTML", "MarkDown"]
   section = ["HTML", "RSS"]
   taxonomy = ["HTML"]

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -18,6 +18,9 @@ noscript = "Theme FixIt works best with JavaScript enabled."
 # === baseof ===
 
 # === Taxonomy ===
+[archives]
+other = "Archives"
+
 [allSome]
 other = "All {{ .Some }}"
 

--- a/i18n/zh-CN.toml
+++ b/i18n/zh-CN.toml
@@ -19,6 +19,9 @@ noscript = "FixIt 主题在启用 JavaScript 的情况下效果最佳。"
 # === baseof ===
 
 # === Taxonomy ===
+[archives]
+other = "归档"
+
 [allSome]
 other = "所有{{ .Some }}"
 

--- a/i18n/zh-TW.toml
+++ b/i18n/zh-TW.toml
@@ -19,6 +19,8 @@ noscript = "FixIt 主題在啟用 JavaScript 的情況下效果最佳。"
 # === baseof ===
 
 # === Taxonomy ===
+[archives]
+other = "歸檔"
 [allSome]
 other = "所有{{ .Some }}"
 

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -8,6 +8,7 @@
     <div class="header">
       {{- /* Title */ -}}
       <h1 class="single-title animate__animated animate__pulse animate__faster">
+        {{- dict "Class" "fa-solid fa-feather fa-fw me-1" | partial "plugin/icon.html" -}}
         {{- .Params.Title | default (T .Section) | default .Section | dict "Some" | T "allSome" }} <sup>{{ .Pages.Len }}</sup>
       </h1>
       {{- /* Total word count */ -}}
@@ -37,7 +38,10 @@
       {{- end -}}
       {{- partial "recently-updated.html" . -}}
       {{- range $pages.PageGroups -}}
-        <h2 class="group-title">{{ .Key }}</h2>
+        <h2 class="group-title">
+          {{- dict "Class" "fa-regular fa-calendar fa-fw me-1" | partial "plugin/icon.html" -}}
+          {{- .Key -}}
+        </h2>
         {{- range .Pages -}}
           <article class="archive-item">
             <a href="{{ .RelPermalink }}" class="archive-item-link">

--- a/layouts/index.archives.html
+++ b/layouts/index.archives.html
@@ -1,19 +1,22 @@
 {{- define "title" -}}
-  {{- .Params.Title | default (T .Section) | default .Section | dict "Some" | T "allSome" -}}
+  {{- .Params.Title | default (T "archives") -}}
   {{- if .Site.Params.withSiteTitle }} {{ .Site.Params.titleDelimiter }} {{ .Site.Title }}{{- end -}}
 {{- end -}}
 
 {{- define "content" -}}
+  {{- /* All Posts */ -}}
+  {{- $pages := where .Site.RegularPages "Type" "posts" -}}
+
   <div class="page archive">
     <div class="header">
       {{- /* Title */ -}}
       <h1 class="single-title animate__animated animate__pulse animate__faster">
-        {{- .Params.Title | default (T .Section) | default .Section | dict "Some" | T "allSome" }} <sup>{{ .Pages.Len }}</sup>
+        {{- .Params.Title | default (T "archives") }} <sup>{{ $pages.Len }}</sup>
       </h1>
       {{- /* Total word count */ -}}
       {{- /* See https://github.com/hugo-fixit/FixIt/issues/124 */ -}}
       {{- $localData := newScratch -}}
-      {{- range .Pages -}}
+      {{- range $pages -}}
         {{- $localData.Add "totalWordCount" .WordCount -}}
       {{- end -}}
       {{- with ($localData.Get "totalWordCount") -}}
@@ -28,14 +31,13 @@
     </div>
 
     {{- /* Paginate */ -}}
-    {{- if .Pages -}}
-      {{- $pages := .Pages.GroupByDate "2006" -}}
-      {{- with .Site.Params.section.paginate | default .Site.Params.paginate -}}
+    {{- if $pages -}}
+      {{- $pages = $pages.GroupByDate "2006" -}}
+      {{- with .Site.Params.archives.paginate | default .Site.Params.paginate -}}
         {{- $pages = $.Paginate $pages . -}}
       {{- else -}}
         {{- $pages = .Paginate $pages -}}
       {{- end -}}
-      {{- partial "recently-updated.html" . -}}
       {{- range $pages.PageGroups -}}
         <h2 class="group-title">{{ .Key }}</h2>
         {{- range .Pages -}}
@@ -48,7 +50,7 @@
               {{- .LinkTitle -}}
             </a>
             <span class="archive-item-date" title='{{ "2006-01-02 15:04:05" | .Date.Format }}'>
-              {{- .Date | dateFormat ($.Site.Params.section.dateFormat | default "01-02") -}}
+              {{- .Date | dateFormat ($.Site.Params.archives.dateFormat | default "01-02") -}}
             </span>
           </article>
         {{- end -}}

--- a/layouts/index.archives.html
+++ b/layouts/index.archives.html
@@ -11,6 +11,7 @@
     <div class="header">
       {{- /* Title */ -}}
       <h1 class="single-title animate__animated animate__pulse animate__faster">
+        {{- dict "Class" "fa-solid fa-box-archive fa-fw me-1" | partial "plugin/icon.html" -}}
         {{- .Params.Title | default (T "archives") }} <sup>{{ $pages.Len }}</sup>
       </h1>
       {{- /* Total word count */ -}}
@@ -39,7 +40,10 @@
         {{- $pages = .Paginate $pages -}}
       {{- end -}}
       {{- range $pages.PageGroups -}}
-        <h2 class="group-title">{{ .Key }}</h2>
+        <h2 class="group-title">
+          {{- dict "Class" "fa-regular fa-calendar fa-fw me-1" | partial "plugin/icon.html" -}}
+          {{- .Key -}}
+        </h2>
         {{- range .Pages -}}
           <article class="archive-item">
             <a href="{{ .RelPermalink }}" class="archive-item-link">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -33,7 +33,7 @@
           {{- /* Author */ -}}
           {{- if ne .Site.Params.footer.author false -}}
             <span class="author" itemprop="copyrightHolder">
-              {{ partial "plugin/link.html" (dict "Destination" ($.Site.Params.author.link | default .Site.Home.RelPermalink) "Content" .Site.Params.author.name) -}}
+              {{ partial "plugin/link.html" (dict "Destination" ($.Site.Params.author.link | default (.Scratch.Get "homeRelPermalink")) "Content" .Site.Params.author.name) -}}
             </span>
           {{- end -}}
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,10 +1,11 @@
 {{- $buildDrafts := .Site.BuildDrafts -}}
+{{- $homeRelPermalink := .Scratch.Get "homeRelPermalink" -}}
 
 {{- /* Desktop header */ -}}
 <header class="desktop animate__faster" id="header-desktop">
   <div class="header-wrapper"{{ if .Site.Params.githubCorner.enable }} data-github-corner="{{ .Site.Params.githubCorner.position }}"{{ end }}>
     <div class="header-title">
-      <a href="{{ .Site.Home.RelPermalink }}" title="{{ .Site.Title }}">
+      <a href="{{ $homeRelPermalink }}" title="{{ .Site.Title }}">
         {{- with .Site.Params.header.title -}}
           {{- with .logo -}}
             {{- dict "Src" . "Class" "logo" "Alt" $.Site.Title | partial "plugin/image.html" -}}
@@ -154,7 +155,7 @@
   <div class="header-container">
     <div class="header-wrapper">
       <div class="header-title">
-        <a href="{{ .Site.Home.RelPermalink }}" title="{{ .Site.Title }}">
+        <a href="{{ $homeRelPermalink }}" title="{{ .Site.Title }}">
           {{- with .Site.Params.header.title -}}
             {{- with .logo -}}
               {{- dict "Src" . "Class" "logo" | partial "plugin/image.html" -}}
@@ -167,13 +168,13 @@
               <span id="{{ $id }}" class="typeit"></span>
               {{- dict $id (slice $id) | dict "typeitMap" | merge ($.Scratch.Get "this") | $.Scratch.Set "this" -}}
             {{- else -}}
-              <span class="header-title-text">{{- .name -}}</span>
+              <span class="header-title-text">{{ .name | default $.Site.Title }}</span>
             {{- end -}}
             {{- with .post -}}
               <span class="header-title-post">{{ . | safeHTML }}</span>
             {{- end -}}
           {{- else -}}
-            <span class="header-title-text">{{- .Site.Title -}}</span>
+            <span class="header-title-text">{{ .Site.Title }}</span>
           {{- end -}}
         </a>
         {{- with .Site.Params.header.subtitle -}}

--- a/layouts/partials/init/global.html
+++ b/layouts/partials/init/global.html
@@ -4,3 +4,8 @@
 {{- $customFilePath = dict "profile" ($customFilePath.profile | default "custom/profile.html") | merge $customFilePath -}}
 {{- $customFilePath = dict "footer" ($customFilePath.footer | default "custom/footer.html") | merge $customFilePath -}}
 {{- .Scratch.Set "customFilePath" $customFilePath -}}
+
+{{- /* Set site home relative permalink */ -}}
+{{- $homeRelPermalink := .Site.Home.RelPermalink -}}
+{{- $homeRelPermalink = strings.TrimSuffix "archives/" $homeRelPermalink -}}
+{{- .Scratch.Set "homeRelPermalink" $homeRelPermalink -}}

--- a/layouts/partials/recently-updated.html
+++ b/layouts/partials/recently-updated.html
@@ -10,7 +10,10 @@
       {{- if ne .Lastmod.Unix .Date.Unix }}
         {{- $postCount = add $postCount 1 -}}
         {{- if eq $hasTitle false -}}
-          <h2 class="group-title">{{- T "section.recentlyUpdated" -}}</h2>
+          <h2 class="group-title">
+            {{- dict "Class" "fa-regular fa-calendar-check fa-fw me-1" | partial "plugin/icon.html" -}}
+            {{- T "section.recentlyUpdated" -}}
+          </h2>
           {{- $hasTitle = true -}}
         {{- end -}}
         <article class="archive-item">

--- a/layouts/partials/recently-updated.html
+++ b/layouts/partials/recently-updated.html
@@ -1,3 +1,5 @@
+{{- /* Recently updated pages */ -}}
+{{- /* TODO refactor to support archives, section, taxonomy and term. */ -}}
 {{- if and .Site.Params.section.recentlyUpdated.enable (eq $.Paginator.PageNumber 1) -}}
   {{- $hasTitle := false }}
   {{- $postCount := 0 -}}

--- a/layouts/partials/single/footer.html
+++ b/layouts/partials/single/footer.html
@@ -89,7 +89,7 @@
       {{- end -}}
     </section>
     <section>
-      <span><a href="javascript:void(0);" onclick="window.history.back();">{{ T "single.back" }}</a></span>&nbsp;|&nbsp;<span><a href="{{ .Site.Home.RelPermalink }}">{{ T "single.home" }}</a></span>
+      <span><a href="javascript:void(0);" onclick="window.history.back();">{{ T "single.back" }}</a></span>&nbsp;|&nbsp;<span><a href="{{ .Scratch.Get "homeRelPermalink" }}">{{ T "single.home" }}</a></span>
     </section>
   </div>
 

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -44,17 +44,18 @@
         {{- partial "single/post-author.html" . -}}
         {{- partial "single/post-included-in.html" . -}}
       </div>
+      {{- /* TODO add disclaimer or space between meta and content */ -}}
       <div class="post-meta-line">
         {{- with .PublishDate | dateFormat (.Site.Params.dateformat | default "2006-01-02") -}}
           <span title="{{ dict "Date" ("2006-01-02 15:04:05" | $.PublishDate.Format) | T "single.publishedOnDate" }}">
-            {{- dict "Class" "fa-regular fa-calendar-alt fa-fw me-1" | partial "plugin/icon.html" -}}
+            {{- dict "Class" "fa-solid fa-calendar-days fa-fw me-1" | partial "plugin/icon.html" -}}
             {{- printf `<time datetime="%v">%v</time>` . . | safeHTML -}}
           </span>&nbsp;
         {{- end -}}
         {{- if ne .Lastmod.Unix .PublishDate.Unix }}
           {{- with .Lastmod | dateFormat (.Site.Params.dateformat | default "2006-01-02") -}}
             <span title="{{ dict "Date" ("2006-01-02 15:04:05" | $.Lastmod.Format) | T "single.updatedOnDate" }}">
-              {{- dict "Class" "fa-regular fa-edit fa-fw me-1" | partial "plugin/icon.html" -}}
+              {{- dict "Class" "fa-regular fa-calendar-check fa-fw me-1" | partial "plugin/icon.html" -}}
               {{- printf `<time datetime="%v">%v</time>` . . | safeHTML -}}
             </span>&nbsp;
           {{- end -}}

--- a/layouts/taxonomy/list.html
+++ b/layouts/taxonomy/list.html
@@ -11,19 +11,19 @@
     {{- $termIcon := "" -}}
     {{- $termTitle := .Title -}}
     {{- if eq $taxonomy "category" -}}
-      {{- $termIcon = "fa-regular fa-folder-open fa-fw" -}}
+      {{- $termIcon = "fa-regular fa-folder-open" -}}
     {{- else if eq $taxonomy "tag" -}}
-      {{- $termIcon = "fa-solid fa-tag fa-fw" -}}
+      {{- $termIcon = "fa-solid fa-tag" -}}
     {{- else if eq $taxonomy "collection" -}}
-      {{- $termIcon = "fa-solid fa-layer-group fa-fw" -}}
+      {{- $termIcon = "fa-solid fa-layer-group" -}}
     {{- else -}}
       {{- $termTitle = printf "%v - %v" (T $taxonomy | default $taxonomy) .Title -}}
     {{- end -}}
     <h2 class="single-title animate__animated animate__pulse animate__faster">
       {{- with $termIcon -}}
-        {{- dict "Class" . | partial "plugin/icon.html" }}
-      {{ end -}}
-      {{ $termTitle }}&nbsp;<sup>{{- $pageCount -}}</sup>
+        {{- dict "Class" (add . " fa-fw me-1") | partial "plugin/icon.html" -}}
+      {{- end -}}
+      {{- $termTitle }} <sup>{{ $pageCount }}</sup>
     </h2>
 
     {{- /* Paginate */ -}}

--- a/layouts/taxonomy/terms.html
+++ b/layouts/taxonomy/terms.html
@@ -7,8 +7,19 @@
   {{- $taxonomies := .Data.Plural -}}
 
   <div class="page archive">
+    {{- $termsIcon := "" -}}
+    {{- if eq $taxonomies "categories" -}}
+      {{- $termsIcon = "fa-solid fa-folder-tree" -}}
+    {{- else if eq $taxonomies "tags" -}}
+      {{- $termsIcon = "fa-solid fa-tags" -}}
+    {{- else if eq $taxonomies "collections" -}}
+      {{- $termsIcon = "fa-solid fa-layer-group" -}}
+    {{- end -}}
     {{- /* Title */ -}}
     <h2 class="single-title animate__animated animate__pulse animate__faster">
+      {{- with $termsIcon -}}
+        {{- dict "Class" (add . " fa-fw me-1") | partial "plugin/icon.html" -}}
+      {{- end -}}
       {{- .Params.Title | default (T $taxonomies) | default $taxonomies | dict "Some" | T "allSome" }} <sup>{{ len .Data.Terms.ByCount }}</sup>
     </h2>
     {{- /* Render miscellaneous terms */ -}}

--- a/layouts/taxonomy/terms.html
+++ b/layouts/taxonomy/terms.html
@@ -9,8 +9,7 @@
   <div class="page archive">
     {{- /* Title */ -}}
     <h2 class="single-title animate__animated animate__pulse animate__faster">
-      {{- .Params.Title | default (T $taxonomies) | default $taxonomies | dict "Some" | T "allSome" }}
-      <sup>{{- len .Data.Terms.ByCount -}}</sup>
+      {{- .Params.Title | default (T $taxonomies) | default $taxonomies | dict "Some" | T "allSome" }} <sup>{{ len .Data.Terms.ByCount }}</sup>
     </h2>
     {{- /* Render miscellaneous terms */ -}}
     {{- .Render (add "terms/" $taxonomies) -}}

--- a/layouts/taxonomy/terms/categories.html
+++ b/layouts/taxonomy/terms/categories.html
@@ -9,8 +9,8 @@
       <div class="card-item-wrapper">
         <h3 class="card-item-title">
           <a href='{{ partial "function/escapeurl.html" .RelPermalink }}'>
-            {{ dict "Class" "fa-regular fa-folder fa-fw" | partial "plugin/icon.html" }}
-            {{ .Page.Title }}&nbsp;<sup>{{- len $pages -}}</sup>
+            {{- dict "Class" "fa-regular fa-folder fa-fw me-1" | partial "plugin/icon.html" -}}
+            {{- .Page.Title }} <sup>{{ len $pages }}</sup>
           </a>
         </h3>
         {{- range first 5 $pages -}}

--- a/layouts/taxonomy/terms/collections.html
+++ b/layouts/taxonomy/terms/collections.html
@@ -9,8 +9,8 @@
       <div class="card-item-wrapper">
         <h3 class="card-item-title">
           <a href='{{ partial "function/escapeurl.html" .RelPermalink }}'>
-            {{ dict "Class" "fa-solid fa-layer-group fa-fw" | partial "plugin/icon.html" }}
-            {{ .Page.Title }}&nbsp;<sup>{{- len $pages -}}</sup>
+            {{- dict "Class" "fa-solid fa-layer-group fa-fw me-1" | partial "plugin/icon.html" -}}
+            {{- .Page.Title }} <sup>{{ len $pages }}</sup>
           </a>
         </h3>
         {{- range first 5 $pages -}}


### PR DESCRIPTION
## Usage

1. add `outputFormats.archives` as below:

    ```toml
    [outputFormats]
      # ...
      # FixIt 0.3.0 | NEW Options to make output /archives/index.html file
      [archives]
        path = "archives"
        baseName = "index"
        mediaType = "text/html"
        isPlainText = false
        isHTML = true
        permalinkable = true
    ```

2. add `"archives"` in `outputs.home` as below:

    ```toml
    [outputs]
      home = ["HTML", "RSS", "JSON", "BaiduUrls", "archives"]
      # ...
    ```
 
3. Head to `http://localhost:1313/archives/` or add menu to header.