### PR TITLE
[BUG] giscus theme is different from FixIt theme when initialize

### DIFF
--- a/layouts/partials/single/comment.html
+++ b/layouts/partials/single/comment.html
@@ -324,7 +324,9 @@
             crossorigin="anonymous"
             async
             defer
-          ></script>
+          >
+          document.querySelector("#giscus>script").setAttribute("data-theme",this.isDark ? "dark" : "light");
+        </script>
         </div>
         <noscript>
           Please enable JavaScript to view the comments powered by <a href="https://giscus.app/" rel="external nofollow noopener noreferrer">giscus</a>.


### PR DESCRIPTION
在 `giscus` 初始化时因未修改其中 `<script>` 元素中的 `data-theme` 属性，导致其仍为默认的 `preferred_color_scheme`，会被自动推导至 `dark` 主题。
the attribute:data-theme in the `<script>` element isn't modified when the giscus initialize,which leads to the content of data-theme is also in default which is `preferred_color_scheme` and it automatically infer to dark theme. 