### PR TITLE
:sparkles: Feat: more markers can be added to mapbox

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -669,7 +669,7 @@ class FixIt {
         this._mapboxArr = this._mapboxArr || [];
       }
       this.util.forEach(document.querySelectorAll('.mapbox:empty'), ($mapbox) => {
-        const { lng, lat, zoom, lightStyle, darkStyle, marked, markers, navigation, geolocate, scale, fullscreen} = JSON.parse($mapbox.dataset.options);
+        const { lng, lat, zoom, lightStyle, darkStyle, marked, markers, navigation, geolocate, scale, fullscreen } = JSON.parse($mapbox.dataset.options);
         const mapbox = new mapboxgl.Map({
           container: $mapbox,
           center: [lng, lat],

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -669,7 +669,7 @@ class FixIt {
         this._mapboxArr = this._mapboxArr || [];
       }
       this.util.forEach(document.querySelectorAll('.mapbox:empty'), ($mapbox) => {
-        const { lng, lat, zoom, lightStyle, darkStyle, marked, navigation, geolocate, scale, fullscreen } = JSON.parse($mapbox.dataset.options);
+        const { lng, lat, zoom, lightStyle, darkStyle, marked, markers, navigation, geolocate, scale, fullscreen} = JSON.parse($mapbox.dataset.options);
         const mapbox = new mapboxgl.Map({
           container: $mapbox,
           center: [lng, lat],
@@ -680,6 +680,17 @@ class FixIt {
         });
         if (marked) {
           new mapboxgl.Marker().setLngLat([lng, lat]).addTo(mapbox);
+        }
+        const markerArray = typeof markers === 'string' ? JSON.parse(markers) : markers;
+        if (Array.isArray(markerArray) && markerArray.length > 0) {
+          markerArray.forEach(marker => {
+            const { lng: markerLng, lat: markerLat, description } = marker;
+            const popup = new mapboxgl.Popup({ offset: 25 }).setText(description); 
+            new mapboxgl.Marker()
+              .setLngLat([markerLng, markerLat])
+              .setPopup(popup)
+              .addTo(mapbox);
+          });
         }
         if (navigation) {
           mapbox.addControl(new mapboxgl.NavigationControl(), 'bottom-right');

--- a/layouts/shortcodes/mapbox.html
+++ b/layouts/shortcodes/mapbox.html
@@ -4,7 +4,7 @@
 {{- $lat := cond .IsNamedParams (.Get "lat") (.Get 1) -}}
 {{- $zoom := cond .IsNamedParams (.Get "zoom") (.Get 2) | default 10 -}}
 {{- $marked := cond .IsNamedParams (.Get "marked") (.Get 3) | ne false -}}
-{{- $markers := .Get "markers" | default "[]" -}}
+{{- $markers := cond .IsNamedParams (.Get "markers") (.Get 6) | default "[]" -}}
 {{- $lightStyle := $mapbox.lightStyle -}}
 {{- $darkStyle := $mapbox.darkStyle -}}
 {{- $navigation := $mapbox.navigation -}}
@@ -23,15 +23,13 @@
   {{- $fullscreen = .Get "fullscreen" | ne false | and $fullscreen -}}
   {{- $width = .Get "width" | default $width -}}
   {{- $height = .Get "height" | default $height -}}
-  {{- $markers := .Get "markers" | default "[]" -}}
 {{- else -}}
-  {{- $markers := .Get 4 | default "[]" -}}
-  {{- $lightStyle = .Get 5 | default $lightStyle -}}
-  {{- $darkStyle = .Get 6 | default $darkStyle -}}
+  {{- $lightStyle = .Get 4 | default $lightStyle -}}
+  {{- $darkStyle = .Get 5 | default $darkStyle -}}
 {{- end -}}
 
 {{- $darkStyle = $darkStyle | default $lightStyle -}}
-{{- $options := dict "lng" $lng "lat" $lat "zoom" $zoom "marked" $marked "markers" ($markers)  "lightStyle" $lightStyle "darkStyle" $darkStyle "geolocate" $geolocate "navigation" $navigation "scale" $scale "fullscreen" $fullscreen -}}
+{{- $options := dict "lng" $lng "lat" $lat "zoom" $zoom "marked" $marked "markers" $markers "lightStyle" $lightStyle "darkStyle" $darkStyle "geolocate" $geolocate "navigation" $navigation "scale" $scale "fullscreen" $fullscreen -}}
 
 {{- $attrs := printf `style="width: %v; height: %v;"` $width $height -}}
 <div class="mapbox" data-options="{{ $options | jsonify }}" {{ $attrs | safeHTMLAttr }}></div>

--- a/layouts/shortcodes/mapbox.html
+++ b/layouts/shortcodes/mapbox.html
@@ -4,6 +4,7 @@
 {{- $lat := cond .IsNamedParams (.Get "lat") (.Get 1) -}}
 {{- $zoom := cond .IsNamedParams (.Get "zoom") (.Get 2) | default 10 -}}
 {{- $marked := cond .IsNamedParams (.Get "marked") (.Get 3) | ne false -}}
+{{- $markers := .Get "markers" | default "[]" -}}
 {{- $lightStyle := $mapbox.lightStyle -}}
 {{- $darkStyle := $mapbox.darkStyle -}}
 {{- $navigation := $mapbox.navigation -}}
@@ -22,12 +23,15 @@
   {{- $fullscreen = .Get "fullscreen" | ne false | and $fullscreen -}}
   {{- $width = .Get "width" | default $width -}}
   {{- $height = .Get "height" | default $height -}}
+  {{- $markers := .Get "markers" | default "[]" -}}
 {{- else -}}
-  {{- $lightStyle = .Get 4 | default $lightStyle -}}
-  {{- $darkStyle = .Get 5 | default $darkStyle -}}
+  {{- $markers := .Get 4 | default "[]" -}}
+  {{- $lightStyle = .Get 5 | default $lightStyle -}}
+  {{- $darkStyle = .Get 6 | default $darkStyle -}}
 {{- end -}}
+
 {{- $darkStyle = $darkStyle | default $lightStyle -}}
-{{- $options := dict "lng" $lng "lat" $lat "zoom" $zoom "marked" $marked "lightStyle" $lightStyle "darkStyle" $darkStyle "geolocate" $geolocate "navigation" $navigation "scale" $scale "fullscreen" $fullscreen -}}
+{{- $options := dict "lng" $lng "lat" $lat "zoom" $zoom "marked" $marked "markers" ($markers)  "lightStyle" $lightStyle "darkStyle" $darkStyle "geolocate" $geolocate "navigation" $navigation "scale" $scale "fullscreen" $fullscreen -}}
 
 {{- $attrs := printf `style="width: %v; height: %v;"` $width $height -}}
 <div class="mapbox" data-options="{{ $options | jsonify }}" {{ $attrs | safeHTMLAttr }}></div>


### PR DESCRIPTION
```
{{< mapbox 
    lng=120.13066322374  lat=30.240018034923  zoom=12 marked=true 
    markers="[{\"lng\": 120.13066322374, \"lat\": 30.240018034926, \"description\": \"标记 1\"},{\"lng\": 120.13367222378, \"lat\": 30.245038134925, \"description\": \"标记 2\"},{\"lng\": 120.12866322380,\"lat\": 30.243028134925, \"description\": \"标记 3\"}]" 
    light-style="mapbox://styles/mapbox/streets-zh-v1" >}}

{{< mapbox lng=120.13066322374  lat=30.240018034923  zoom=12 marked=true light-style="mapbox://styles/mapbox/streets-zh-v1" >}}
{{< mapbox 113.953277 22.559102 11 >}}
```
实现效果
<img width="263" alt="Snipaste_2024-09-23_14-11-55" src="https://github.com/user-attachments/assets/49f0c1c9-3ae7-48c4-b228-cbbe10604a5e">
