### PR TITLE
:truck: Feat: supersede `markup.tableOfContents` settings with `params.page.toc`

### DIFF
--- a/assets/css/_core/_base.scss
+++ b/assets/css/_core/_base.scss
@@ -30,7 +30,7 @@ body {
   color: $global-font-color;
   @include overflow-wrap(break-word);
 
-  &[data-theme='dark'] {
+  [data-theme='dark'] & {
     color: $global-font-color-dark;
     background-color: $global-background-color-dark;
   }

--- a/assets/js/head/color-scheme.js
+++ b/assets/js/head/color-scheme.js
@@ -1,0 +1,21 @@
+import params from '@params';
+
+/**
+ * Check theme isDark before body rendering
+ */
+(function () {
+  const localStorage = window.localStorage;
+  if (!localStorage) {
+    return;
+  }
+  let isDark = false;
+  const themeUsed = localStorage.getItem('theme');
+  if (themeUsed) {
+    isDark = themeUsed === 'dark';
+  } else {
+    isDark = params.defaultTheme === 'auto' ?
+      window.matchMedia('(prefers-color-scheme: dark)').matches :
+      params.defaultTheme === 'dark';
+  }
+  isDark && (document.documentElement.dataset.theme = 'dark');
+})();

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -3,7 +3,7 @@ import Util from './util';
 class FixIt {
   constructor() {
     this.config = window.config;
-    this.isDark = document.body.dataset.theme === 'dark';
+    this.isDark = document.documentElement.dataset.theme === 'dark';
     this.util = new Util();
     this.newScrollTop = this.util.getScrollTop();
     this.oldScrollTop = this.newScrollTop;
@@ -89,7 +89,7 @@ class FixIt {
   initSwitchTheme() {
     this.util.forEach(document.getElementsByClassName('theme-switch'), ($themeSwitch) => {
       $themeSwitch.addEventListener('click', () => {
-        document.body.dataset.theme = document.body.dataset.theme === 'dark' ? 'light' : 'dark';
+        document.documentElement.dataset.theme = this.isDark ? 'light' : 'dark';
         this.isDark = !this.isDark;
         window.localStorage?.setItem('theme', this.isDark ? 'dark' : 'light');
         for (let event of this.switchThemeEventSet) {

--- a/hugo.toml
+++ b/hugo.toml
@@ -825,6 +825,20 @@ enableEmoji = true
     # whether to show the full text content in feed.
     fullText = true
 
+  # FixIt 0.3.12 | NEW Custom partials config
+  # Custom partials must be stored in the /layouts/partials/ directory.
+  # Depends on open custom blocks https://fixit.lruihao.cn/references/blocks/
+  [params.customPartials]
+    head = []
+    profile = []
+    aside = []
+    comment = []
+    footer = []
+    widgets = []
+    assets = []
+    postFooterBefore = []
+    postFooterAfter = []
+
   # FixIt 0.2.15 | NEW Developer options
   # Select the scope named `public_repo` to generate personal access token,
   # Configure with environment variable `HUGO_PARAMS_GHTOKEN=xxx`, see https://gohugo.io/functions/os/getenv/#examples

--- a/hugo.toml
+++ b/hugo.toml
@@ -189,11 +189,6 @@ enableEmoji = true
       # whether to use HTML tags directly in the document
       unsafe = true
       xhtml = false
-  # Table Of Contents settings
-  [markup.tableOfContents]
-    ordered = false
-    startLevel = 2
-    endLevel = 6
 
 # -------------------------------------------------------------------------------------
 # Sitemap Configuration
@@ -913,6 +908,10 @@ enableEmoji = true
       auto = true
       # FixIt 0.2.13 | NEW position of TOC ["left", "right"]
       position = "right"
+      # FixIt 0.3.12 | NEW supersede `markup.tableOfContents` settings
+      ordered = false
+      startLevel = 2
+      endLevel = 6
     # FixIt 0.2.13 | NEW Display a message at the beginning of an article to warn the reader that its content might be expired
     [params.page.expirationReminder]
       enable = false
@@ -926,7 +925,7 @@ enableEmoji = true
     [params.page.heading]
       # FixIt 0.3.3 | NEW whether to capitalize automatic text of headings
       capitalize = false
-      # used with `markup.tableOfContents.ordered` parameter
+      # FixIt 0.3.12 | CHANGED must set `params.page.toc.ordered` to true
       [params.page.heading.number]
         # whether to enable auto heading numbering
         enable = false

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,5 +1,6 @@
 {{- /* Read the config and format */ -}}
 {{- $params := .Page.Params | merge site.Params.page -}}
+{{- $ordered := $params.toc.ordered | and -}}
 {{- $h1Format := $params.heading.number.format.h1 | default "{title}" -}}
 {{- $h2Format := $params.heading.number.format.h2 | default "{h2} {title}" -}}
 {{- $h3Format := $params.heading.number.format.h3 | default "{h2}.{h3} {title}" -}}
@@ -7,7 +8,7 @@
 {{- $h5Format := $params.heading.number.format.h5 | default "{h2}.{h3}.{h4}.{h5} {title}" -}}
 {{- $h6Format := $params.heading.number.format.h6 | default "{h2}.{h3}.{h4}.{h5}.{h6} {title}" -}}
 
-{{- if $params.heading.number.enable -}}
+{{- if $ordered -}}
   {{- /* Set the count for child level to 0 */ -}}
   {{- .Page.Scratch.SetInMap "heading-counter" (string (add .Level 1)) 0 -}}
 {{- end -}}
@@ -16,7 +17,7 @@
   {{- $title := .Text -}}
   {{- /* Only enable in main section pages */ -}}
   {{- $onlyMainSection := cond $params.heading.number.onlyMainSection (eq .Page.Type "posts") true -}}
-  {{- if $params.heading.number.enable | and $onlyMainSection -}}
+  {{- if $ordered | and $onlyMainSection -}}
     {{- /* Add 1 to the current level */ -}}
     {{- $headingMap := .Page.Scratch.Get "heading-counter" -}}
     {{- $count := (string .Level) | index $headingMap | int | add 1 -}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,4 @@
 {{- partial "init/index.html" . -}}
-{{- partial "custom.html" . -}}
 
 <!DOCTYPE html>
 <html itemscope itemtype="http://schema.org/WebPage" lang="{{ .Site.LanguageCode }}">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -15,7 +15,8 @@
     {{- partial "head/link.html" . -}}
     {{- partial "head/seo.html" . -}}
     {{- partial "head/script.html" . -}}
-    {{- /*  TODO preload script https://developer.mozilla.org/zh-CN/docs/Web/HTML/Attributes/rel/preload */ -}}
+    {{- /* TODO preload script https://developer.mozilla.org/zh-CN/docs/Web/HTML/Attributes/rel/preload */ -}}
+    {{- /* TODO add config and page config to config.js (static) */ -}}
     {{- /* Custom head */ -}}
     {{- block "custom-head" . }}{{ end -}}
   </head>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -14,15 +14,12 @@
     {{- partial "head/meta.html" . -}}
     {{- partial "head/link.html" . -}}
     {{- partial "head/seo.html" . -}}
+    {{- partial "head/script.html" . -}}
+    {{- /*  TODO preload script https://developer.mozilla.org/zh-CN/docs/Web/HTML/Attributes/rel/preload */ -}}
     {{- /* Custom head */ -}}
     {{- block "custom-head" . }}{{ end -}}
   </head>
   <body data-header-desktop="{{ .Site.Params.header.desktopMode }}" data-header-mobile="{{ .Site.Params.header.mobileMode }}">
-    {{- /* Check theme isDark before body rendering */ -}}
-    {{- /* TODO resources.ExecuteAsTemplate */ -}}
-    {{- $theme := .Site.Params.defaulttheme -}}
-    <script>(window.localStorage?.getItem('theme') ? localStorage.getItem('theme') === 'dark' : ('{{ $theme }}' === 'auto' ? window.matchMedia('(prefers-color-scheme: dark)').matches : '{{ $theme }}' === 'dark')) && document.body.setAttribute('data-theme', 'dark');</script>
-
     {{- /* Body wrapper */ -}}
     <div class="wrapper" data-page-style="{{ (partial `function/params.html`).pageStyle | default `normal` }}">
       {{- partial "header.html" . -}}

--- a/layouts/partials/custom.html
+++ b/layouts/partials/custom.html
@@ -1,31 +1,62 @@
-{{- /*
-  To avoid upgrade conflicts and facilitate the reference of theme components,
-  it's strongly recommended to copy this file from the theme to your project and override it.
-*/ -}}
-
 {{- define "custom-head" -}}
+  {{- $ctx := . -}}
+  {{- range .Site.Params.customPartials.head -}}
+    {{- partial . $ctx -}}
+  {{- end -}}
 {{- end -}}
 
 {{- define "custom-profile" -}}
+  {{- $ctx := . -}}
+  {{- range .Site.Params.customPartials.profile -}}
+    {{- partial . $ctx -}}
+  {{- end -}}
 {{- end -}}
 
 {{- define "custom-aside" -}}
+  {{- $ctx := . -}}
+  {{- range .Site.Params.customPartials.aside -}}
+    {{- partial . $ctx -}}
+  {{- end -}}
 {{- end -}}
 
 {{- define "custom-comment" -}}
+  {{- $ctx := . -}}
+  {{- range .Site.Params.customPartials.comment -}}
+    {{- partial . $ctx -}}
+  {{- end -}}
 {{- end -}}
 
 {{- define "custom-footer" -}}
+  {{- $ctx := . -}}
+  {{- range .Site.Params.customPartials.footer -}}
+    {{- partial . $ctx -}}
+  {{- end -}}
 {{- end -}}
 
 {{- define "custom-widgets" -}}
+  {{- $ctx := . -}}
+  {{- range .Site.Params.customPartials.widgets -}}
+    {{- partial . $ctx -}}
+  {{- end -}}
 {{- end -}}
 
 {{- define "custom-assets" -}}
+  {{- $ctx := . -}}
+  {{- range .Site.Params.customPartials.assets -}}
+    {{- partial . $ctx -}}
+  {{- end -}}
 {{- end -}}
 
 {{- define "custom-post__footer:before" -}}
+  {{- $ctx := . -}}
+  {{- range .Site.Params.customPartials.postFooterBefore -}}
+    {{- partial . $ctx -}}
+  {{- end -}}
 {{- end -}}
 
 {{- define "custom-post__footer:after" -}}
+  {{- $ctx := . -}}
+  {{- range .Site.Params.customPartials.postFooterAfter -}}
+    {{- partial . $ctx -}}
+  {{- end -}}
 {{- end -}}

--- a/layouts/partials/head/script.html
+++ b/layouts/partials/head/script.html
@@ -1,0 +1,9 @@
+{{- $fingerprint := .Scratch.Get "fingerprint" -}}
+
+{{- /* Check theme isDark before body rendering */ -}}
+{{- $options := dict "targetPath" "js/head/color-scheme.min.js" "minify" hugo.IsProduction -}}
+{{- $options := dict "defaultTheme" .Site.Params.defaulttheme | dict "params" | merge $options -}}
+{{- if not hugo.IsProduction -}}
+  {{- $options = dict "sourceMap" "external" | merge $options -}}
+{{- end -}}
+{{- dict "Source" (resources.Get "js/head/color-scheme.js") "Build" $options "Fingerprint" $fingerprint | partial "plugin/script.html" -}}

--- a/layouts/partials/init/index.html
+++ b/layouts/partials/init/index.html
@@ -1,4 +1,4 @@
-{{- .Scratch.Set "version" "v0.3.12-314d24a3" -}}
+{{- .Scratch.Set "version" "v0.3.12-01d42625" -}}
 {{- .Scratch.Set "this" dict -}}
 
 {{- partial "init/detection-env.html" . -}}

--- a/layouts/partials/init/index.html
+++ b/layouts/partials/init/index.html
@@ -1,4 +1,4 @@
-{{- .Scratch.Set "version" "v0.3.12-185c6803" -}}
+{{- .Scratch.Set "version" "v0.3.12-314d24a3" -}}
 {{- .Scratch.Set "this" dict -}}
 
 {{- partial "init/detection-env.html" . -}}

--- a/layouts/partials/init/patch.html
+++ b/layouts/partials/init/patch.html
@@ -6,7 +6,7 @@
 {{- if eq $toc true -}}
   {{- $toc = dict "enable" true | merge .Site.Params.page.toc -}}
 {{- else if eq $toc false -}}
-  {{- $toc = dict "enable" false -}}
+  {{- $toc = dict "enable" false | merge .Site.Params.page.toc -}}
 {{- end -}}
 {{- .Scratch.Set "toc" $toc -}}
 

--- a/layouts/partials/single/comment.html
+++ b/layouts/partials/single/comment.html
@@ -153,7 +153,7 @@
       {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/style.html" -}}
       {{- $source := $cdn.walineJS | default "lib/waline/waline.js" -}}
       {{- dict "Source" $source "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
-      {{- $commentConfig = dict "el" "#waline" "serverURL" $waline.serverURL "lang" .Lang "dark" "body[data-theme='dark']" | dict "waline" | merge $commentConfig -}}
+      {{- $commentConfig = dict "el" "#waline" "serverURL" $waline.serverURL "lang" .Lang "dark" "html[data-theme='dark']" | dict "waline" | merge $commentConfig -}}
       {{- $commentConfig = dict "copyright" true "imageUploader" false "highlighter" false "texRenderer" false "search" false | dict "waline" | merge $commentConfig -}}
       {{- with $waline.pageview -}}
         {{- $commentConfig = dict "pageview" . | dict "waline" | merge $commentConfig -}}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -7,7 +7,7 @@
   {{- $title := title .Title -}}
   {{- $params := partial "function/params.html" -}}
   {{- $toc := .Scratch.Get "toc" -}}
-  {{- $tocEmpty := eq .TableOfContents `<nav id="TableOfContents"></nav>` -}}
+  {{- $showToc := $toc.enable | and (gt (len .Fragments.Headings) 0) -}}
 
   <aside class="aside-collection animate__animated animate__fadeIn animate__faster" aria-label="{{ T "collections" }}">
     {{- /* Collection List */ -}}
@@ -146,14 +146,15 @@
     {{- end -}}
 
     {{- /* Static TOC */ -}}
-    {{- if (ne $toc.enable false) | and (ne $tocEmpty true) -}}
+    {{- if $showToc -}}
+      {{- $tableOfContents := .Fragments.ToHTML ($toc.startLevel | int) ($toc.endLevel | int) ($toc.ordered | default false) -}}
       <div class="details toc{{ with $params.password }} encrypted-hidden{{ end }}" id="toc-static" data-kept="{{ if $toc.keepStatic }}true{{ else }}false{{ end }}">
         <div class="details-summary toc-title">
           <span>{{ T "single.contents" }}</span>
           <span>{{ dict "Class" "details-icon fa-solid fa-angle-right" | partial "plugin/icon.html" }}</span>
         </div>
         <div class="details-content toc-content" id="toc-content-static">
-          {{- dict "Content" .TableOfContents "Ruby" $params.ruby "Fraction" $params.fraction "Fontawesome" $params.fontawesome | partial "function/content.html" | safeHTML -}}
+          {{- dict "Content" $tableOfContents "Ruby" $params.ruby "Fraction" $params.fraction "Fontawesome" $params.fontawesome | partial "function/content.html" | safeHTML -}}
         </div>
       </div>
     {{- end -}}
@@ -203,7 +204,7 @@
 
   <aside class="toc" id="toc-auto" aria-label="{{ T "single.contents" }}">
     {{- /* Auto TOC */ -}}
-    {{- if (ne $toc.enable false) | and (ne $tocEmpty true) -}}
+    {{- if $showToc -}}
       <h2 class="toc-title{{ with $params.password }} encrypted-hidden{{ end }}">
         {{- T "single.contents" -}}&nbsp;
         {{- dict "Class" "toc-icon fa-solid fa-angle-down fa-fw" | partial "plugin/icon.html" -}}


### PR DESCRIPTION
Fixed #505