### PR TITLE
🐛 fix:  RSS rendering issues caused by XML escape

### DIFF
--- a/layouts/partials/feed/rss.html
+++ b/layouts/partials/feed/rss.html
@@ -65,11 +65,11 @@
         {{- with $image }}
           {{- $content = add (printf "<img src=%q alt=%q referrerpolicy=%q>" . "featured image" "no-referrer") $content | safeHTML }}
         {{- end }}
-        {{- $content | transform.XMLEscape | safeHTML }}
+        {{- $content | safeHTML }}
         {{- "]]>" | safeHTML -}}
       </description>
       {{- else }}
-      <description>{{ (.Summary | default .Description | default .Title) | transform.XMLEscape | safeHTML }}</description>
+      <description>{{ (.Summary | default .Description | default .Title) | safeHTML }}</description>
       {{- end }}
     </item>
     {{- end }}


### PR DESCRIPTION
This pull request fixes the RSS rendering issues that were caused by XML escape. The issue was resolved by removing the XML escape transformation from the content in the RSS feed.