### PR TITLE
WIP: Refactor image rendering

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,14 +1,13 @@
-{{- /* TODO refactor */ -}}
 {{- $params := .Page.Params | merge site.Params.page -}}
 {{- if .Title | and .Text -}}
   {{- $linked := ne $params.lightgallery false -}}
   <figure>
-    {{- dict "Src" .Destination "Alt" .Text "Caption" .Text "Title" .Title "Linked" $linked "Responsive" true "Resources" .Page.Resources | partial "plugin/image.html" -}}
+    {{- dict "Src" .Destination "Alt" .Text "Caption" .Text "Title" .Title "Linked" $linked "Resources" .Page.Resources | partial "plugin/image.html" -}}
     <figcaption class="image-caption">
       {{- .Text | safeHTML -}}
     </figcaption>
   </figure>
 {{- else -}}
   {{- $linked := (eq $params.lightgallery "force") | or ($params.lightgallery | and (ne .Title "")) -}}
-  {{- dict "Src" .Destination "Alt" .Text "Title" .Title "Linked" $linked "Responsive" true "Resources" .Page.Resources | partial "plugin/image.html" -}}
+  {{- dict "Src" .Destination "Alt" .Text "Title" .Title "Linked" $linked "Resources" .Page.Resources | partial "plugin/image.html" -}}
 {{- end -}}


### PR DESCRIPTION
The current image rendering is too complicated, and some image rendering sizes do not meet expectations.

There are several things to consider when refactoring:

- [ ] Regular images (different formats)
- [ ] Remote images (different formats)
- [ ] Base64 images

There are also different rendering ways to consider:

- [ ] Image render hook (Markdown)
- [ ] Image shortcode
- [ ] `img` tag (HTML) 

Other dimensions to consider:

- [ ] lightgallery render (maybe the plugin will be changed)
- [ ] Responsive images
- [ ] Lazy Loading