### PR TITLE
:sparkles: Feat: support `bluesky` shortcode

### DIFF
--- a/layouts/shortcodes/bluesky.html
+++ b/layouts/shortcodes/bluesky.html
@@ -1,0 +1,7 @@
+{{- $link := .Get "link"  -}}
+{{- $query := querify "url" $link -}}
+{{- $request := printf "https://embed.bsky.app/oembed?%s" $query -}}
+{{- $jsonOembed := resources.GetRemote $request -}}
+{{- $jsonOembed = $jsonOembed | transform.Unmarshal -}}
+{{- $jsonOHTML := $jsonOembed.html -}}
+{{- $jsonOHTML | safeHTML -}}


### PR DESCRIPTION
`bluesky` is a shortcode to embed a post from [Bluesky][bluesky].

The `bluesky` shortcode has the following named parameters:

- **link** _[required]_

    URL of the Bluesky post.

Example `bluesky` input:

```markdown
{{< bluesky link="https://bsky.app/profile/bsky.app/post/3latotljnec2h" >}}
```