### PR TITLE
Optimize some styles

### DIFF
--- a/.github/workflows/fixit-component-list.yml
+++ b/.github/workflows/fixit-component-list.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch: # Run workflow manually (without waiting for the cron to be called), through the GitHub Actions Workflow page directly
 permissions:
   contents: write # To write the generated contents to the readme
+  pull-requests: write # To create a pull request
 
 jobs:
   generate-component-list:
@@ -21,8 +22,18 @@ jobs:
           comment_tag_name: HUGO_FIXIT_COMPONENTS
           readme_path: 'README.md,README.zh-cn.md'
           template: "- [{$repo.name}]({$repo.html_url})\\\n  {$repo.description}"
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+      # - name: Commit changes
+      #   uses: stefanzweifel/git-auto-commit-action@v5
+      #   with:
+      #     commit_message: ':memo: Docs: update hugo-fixit component list'
+      #     commit_author: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
         with:
-          commit_message: ':memo: Docs: update hugo-fixit component list'
-          commit_author: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
+          title: 'Update hugo-fixit component list'
+          commit-message: ':memo: Docs: update hugo-fixit component list'
+          body: 'This PR updates the hugo-fixit component list in the README.'
+          base: main
+          branch: update-component-list
+          labels: documentation
+          reviewers: Lruihao

--- a/assets/css/_partials/_single/_toc.scss
+++ b/assets/css/_partials/_single/_toc.scss
@@ -8,6 +8,24 @@
   .toc-content {
     font-size: $toc-content-font-size;
 
+    // 使目录也能像正文一样正常显示行内代码
+    code, pre {
+      padding: 0.2em 0.4em;
+      margin: 0;
+      font-family: $code-font-family;
+      color: $code-color;  
+      background-color: $code-background-color;
+      text-decoration: inherit;
+      @include border-radius($global-border-radius);   
+      @include overflow-wrap(break-word);
+      @include line-break(auto);
+  
+      [data-theme='dark'] & {
+        color: $code-color-dark;
+        background-color: rgba(99, 110, 123, 0.4);
+      }
+    }
+
     ul {
       text-indent: -0.8em;
       padding-left: 0.8em;


### PR DESCRIPTION
make inline code inside toc can be displayed exactly as those inside content .  
使目录内的行内代码块也能像正文中的行内代码块那样显示 。