### PR TITLE
:tada: Feat: add color preview models support

### DIFF
--- a/assets/css/_page/_single.scss
+++ b/assets/css/_page/_single.scss
@@ -2,6 +2,7 @@
 @import '../_partials/_single/fixit-decryptor';
 @import '../_partials/_single/collections';
 @import '../_partials/_single/related';
+@import '../_partials/_single/color-preview';
 
 .single {
   .single-title {

--- a/assets/css/_partials/_single/_color-preview.scss
+++ b/assets/css/_partials/_single/_color-preview.scss
@@ -1,0 +1,22 @@
+// Color preview styles for inline code
+.color-code {
+  position: relative;
+  #{$rootPrefix}color-code-size: 0.64em;
+
+  .color-preview {
+    display: inline-block;
+    width: var(#{$rootPrefix}color-code-size);
+    height: var(#{$rootPrefix}color-code-size);
+    border-radius: 50%;
+    margin-right: 0.25em;
+    vertical-align: middle;
+    border: 1px solid;
+    border-color: var(#{$rootPrefix}color-preview-border-color, #d1d9e0b3);
+    pointer-events: none;
+    transform: translateY(-1px);
+
+    [data-theme='dark'] & {
+      #{$rootPrefix}color-preview-border-color: #3d444db3;
+    }
+  }
+}

--- a/layouts/_partials/function/color-preview.html
+++ b/layouts/_partials/function/color-preview.html
@@ -1,0 +1,34 @@
+{{- /*
+  Color preview rendering
+  This function adds color visualization to code elements that contain ONLY color values.
+  Supports HEX, RGB, and HSL color formats like GitHub's color preview feature.
+  
+  Examples:
+  `#0969DA` -> displays a blue color preview circle
+  `rgb(9, 105, 218)` -> displays a blue color preview circle  
+  `hsl(212, 92%, 45%)` -> displays a blue color preview circle
+  
+  But excludes:
+  `` `#0969DA` `` -> renders as normal code (syntax example)
+  `test #0969DA` -> renders as normal code (has leading text)
+  ` #0969DA` -> renders as normal code (has leading space)
+  `#0969DA ` -> renders as normal code (has trailing space)
+*/ -}}
+
+{{- $content := . -}}
+
+{{- /* Only apply color preview to code elements that contain EXACTLY a color value and nothing else */ -}}
+
+{{- /* HEX color pattern: code must contain ONLY #RRGGBB (6 digits) */ -}}
+{{- $content = replaceRE `<code>(#[0-9a-fA-F]{6})</code>` `<code class="color-code"><span class="color-preview" style="background-color: $1;" title="Color: $1"></span>$1</code>` $content -}}
+
+{{- /* HEX color pattern: code must contain ONLY #RGB (3 digits) */ -}}
+{{- $content = replaceRE `<code>(#[0-9a-fA-F]{3})</code>` `<code class="color-code"><span class="color-preview" style="background-color: $1;" title="Color: $1"></span>$1</code>` $content -}}
+
+{{- /* RGB color pattern: code must contain ONLY rgb(r,g,b) */ -}}
+{{- $content = replaceRE `<code>(rgb\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*\))</code>` `<code class="color-code"><span class="color-preview" style="background-color: $1;" title="Color: $1"></span>$1</code>` $content -}}
+
+{{- /* HSL color pattern: code must contain ONLY hsl(h,s%,l%) */ -}}
+{{- $content = replaceRE `<code>(hsl\(\s*\d+\s*,\s*\d+%\s*,\s*\d+%\s*\))</code>` `<code class="color-code"><span class="color-preview" style="background-color: $1;" title="Color: $1"></span>$1</code>` $content -}}
+
+{{- return $content -}}

--- a/layouts/_partials/function/content.html
+++ b/layouts/_partials/function/content.html
@@ -16,6 +16,7 @@
 
   {{- $content = partial "function/task-lists.html" $content -}}
   {{- $content = partial "function/marked-text.html" $content -}}
+  {{- $content = partial "function/color-preview.html" $content -}}
   {{- $content = partial "function/escape.html" $content -}}
 
 {{- end -}}


### PR DESCRIPTION
### FixIt Docs

- [English](http:/fixit.lruihao.cn/documentation/content-management/markdown-syntax/extended/#color-preview)
- [中文](http:/fixit.lruihao.cn/zh-cn/documentation/content-management/markdown-syntax/extended/#color-preview)

### Usage

In Content, you can call out colors within a sentence by using backticks. A supported color model within backticks will display a visualization of the color.

```markdown
The background color is `#ffffff` for light mode and `#000000` for dark mode.
```

The background color is `#ffffff` for light mode and `#000000` for dark mode.

Here are the currently supported color models.

| Color | Syntax             | Example                    | Output               |
| ----- | ------------------ | -------------------------- | -------------------- |
| HEX   | `` `#RRGGBB` ``    | `` `#0969DA` ``            | `#0969DA`            |
| RGB   | `` `rgb(R,G,B)` `` | `` `rgb(9, 105, 218)` ``   | `rgb(9, 105, 218)`   |
| HSL   | `` `hsl(H,S,L)` `` | `` `hsl(212, 92%, 45%)` `` | `hsl(212, 92%, 45%)` |

> [!NOTE]
>
> - A supported color model cannot have any leading or trailing spaces within the backticks.
> - The visualization of the color is compatible with GitHub [Supported color models][supported-color-models].

---

在文章内容中，可以使用反引号在句子中标注颜色。反引号内支持的颜色模型将显示颜色的可视化效果。

```markdown
对于 `Light` 模式，背景色为`#ffffff`，对于 `Dark` 模式，背景颜色为`#000000`。
```

对于 `Light` 模式，背景色为`#ffffff`，对于 `Dark` 模式，背景颜色为`#000000`。

下面是当前支持的颜色模型。

| Color | 语法               | 示例                       | 输出                 |
| ----- | ------------------ | -------------------------- | -------------------- |
| HEX   | `` `#RRGGBB` ``    | `` `#0969DA` ``            | `#0969DA`            |
| RGB   | `` `rgb(R,G,B)` `` | `` `rgb(9, 105, 218)` ``   | `rgb(9, 105, 218)`   |
| HSL   | `` `hsl(H,S,L)` `` | `` `hsl(212, 92%, 45%)` `` | `hsl(212, 92%, 45%)` |

> [!NOTE]
>
> - 支持的颜色模型在反引号内不能有任何前导或尾随空格。
> - 颜色的可视化效果兼容 GitHub [支持的颜色模型][supported-color-models-zh]。

[supported-color-models]: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#supported-color-models
[supported-color-models-zh]: https://docs.github.com/zh/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#supported-color-models

