### PR TITLE
:sparkles: Feat: add `enableTranslationMerge` parameter for merging m…

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -348,6 +348,11 @@ mainSections = []
   indexWithSubtitle = false
   # FixIt 0.3.13 | NEW whether to show summary in plain text
   summaryPlainify = false
+  # FixIt 0.4.0 | NEW whether to enable merging missing translations from other languages
+  # when set to true, missing translations from other languages will be merged and displayed
+  # default is false for better performance, especially for single-language sites
+  # set to true if your site has multiple languages and you want to show all content
+  enableTranslationMerge = false
   # FixIt 0.2.14 | NEW FixIt will, by default, inject a theme meta tag in the HTML head on the home page only.
   # You can turn it off, but we would really appreciate if you don’t, as this is a good way to watch FixIt's popularity on the rise.
   disableThemeInject = false

--- a/layouts/_partials/init/global.html
+++ b/layouts/_partials/init/global.html
@@ -1,5 +1,14 @@
+{{- $pages := .Site.RegularPages }}
+
+{{- /* Merge missing translations from other languages */ -}}
+{{- if .Site.Params.enableTranslationMerge -}}
+  {{- range .Site.Home.Translations -}}
+    {{- $pages = $pages | lang.Merge .Site.RegularPages -}}
+  {{- end -}}
+{{- end -}}
+
 {{- /* Set pages of main sections */ -}}
-{{- $pages := where .Site.RegularPages "Section" "in" .Site.MainSections -}}
+{{- $pages = where $pages "Section" "in" .Site.MainSections -}}
 {{- $pages = $pages | union (where .Site.RegularPages "Type" "in" .Site.MainSections) -}}
 {{- .Site.Store.Set "mainSectionPages" $pages -}}
 


### PR DESCRIPTION
…issing translations from other languages

- Add enableTranslationMerge parameter to control translation merging
- Default to false for better performance, especially for single-language sites
- Update comments to reflect the new default behavior
- Implement conditional translation merging in global.html"

> [!NOTE]
> This won't create new pages, if you need empty placeholder pages, you might need [shortcode-missing-translation](https://github.com/hugo-fixit/shortcode-missing-translation).