### PR TITLE
fix: Params configurations case insensitive for mathjax and watermark

### DIFF
--- a/assets/js/lib/mathjax.js
+++ b/assets/js/lib/mathjax.js
@@ -36,7 +36,6 @@ window.MathJax = {
     },
   },
   options: {
-    ignoreHtmlClass: 'comment',
     processHtmlClass: 'content',
     ...params.options,
   }

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1053,19 +1053,10 @@ class FixIt {
   }
 
   initWatermark() {
-    this.config.watermark?.enable &&
-      new Watermark({
-        content: this.config.watermark.content || `${document.querySelector('footer .fixit-icon')?.outerHTML ?? ''} FixIt Theme`,
-        appendTo: '.widgets',
-        opacity: this.config.watermark.opacity,
-        width: this.config.watermark.width,
-        height: this.config.watermark.height,
-        rowSpacing: this.config.watermark.rowspacing,
-        colSpacing: this.config.watermark.colspacing,
-        rotate: this.config.watermark.rotate,
-        fontSize: this.config.watermark.fontsize,
-        fontFamily: this.config.watermark.fontfamily
-      });
+    if (!this.config.watermark?.enable) {
+      return;
+    }
+    new Watermark(this.config.watermark);
   }
 
   initPangu() {

--- a/hugo.toml
+++ b/hugo.toml
@@ -1149,7 +1149,26 @@ mainSections = []
           # more loader config e.g source, dependencies, provides etc.
         [params.page.math.mathjax.options]
           enableMenu = true
-          # more options config e.g. skipHtmlTags, ignoreHtmlClass etc.
+          # HTML tags that won't be searched for math
+          skipHtmlTags = [
+            "script",
+            "noscript",
+            "style",
+            "textarea",
+            "pre",
+            "code",
+            "math",
+            "select",
+            "option",
+            "mjx-container"
+          ]
+          # class that marks tags not to search
+          ignoreHtmlClass = "mathjax_ignore"
+          # HTML tags that can appear within math
+          [params.page.math.mathjax.options.includeHtmlTags]
+            # "#comment" = ""
+            # br = "\n"
+            # wbr = ""
     # Code wrapper config
     [params.page.code]
       # FixIt 0.3.9 | NEW whether to enable the code wrapper

--- a/layouts/_partials/assets.html
+++ b/layouts/_partials/assets.html
@@ -110,8 +110,20 @@
     {{- $mathjax := $math.mathjax -}}
     {{- $source := "js/lib/mathjax.js" -}}
     {{- $options := dict "targetPath" "js/lib/mathjax.min.js" "minify" hugo.IsProduction -}}
-    {{- $mathjaxOpts := $mathjax.options | default dict -}}
-    {{- $mathjaxOpts = dict "enableMenu" $mathjaxOpts.enablemenu | merge $mathjaxOpts -}}
+    {{- $mathjaxOptsConfig := $mathjax.options | default dict -}}
+    {{- $mathjaxOpts := default dict -}}
+    {{- with $mathjaxOptsConfig.enableMenu -}}
+      {{- $mathjaxOpts = dict "enableMenu" . | merge $mathjaxOpts -}}
+    {{- end -}}
+    {{- with $mathjaxOptsConfig.ignoreHtmlClass -}}
+      {{- $mathjaxOpts = dict "ignoreHtmlClass" . | merge $mathjaxOpts -}}
+    {{- end -}}
+    {{- with $mathjaxOptsConfig.skipHtmlTags -}}
+      {{- $mathjaxOpts = dict "skipHtmlTags" . | merge $mathjaxOpts -}}
+    {{- end -}}
+    {{- with $mathjaxOptsConfig.includeHtmlTags -}}
+      {{- $mathjaxOpts = dict "includeHtmlTags" . | merge $mathjaxOpts -}}
+    {{- end -}}
     {{- $params := dict
       "cdn" $mathjax.cdn
       "tex" ($mathjax.tex | default dict)
@@ -192,15 +204,14 @@
 {{- if eq .Site.Params.watermark.enable true -}}
   {{- $source := $cdn.cellWatermarkJS | default "lib/cell-watermark/watermark.min.js" -}}
   {{- dict "Source" $source "Fingerprint" $fingerprint "Defer" true | dict "Page" . "Data" | partial "store/script.html" -}}
-  {{- /* All the Params configurations are case insensitive since Hugo 0.18 */ -}}
   {{- $watermarkConfig := .Site.Params.watermark | default dict -}}
   {{- $watermarkConfig = dict
     "appendTo" ".widgets"
     "content" ($watermarkConfig.content | default $author.name | default .Site.Title)
-    "rowSpacing" $watermarkConfig.rowspacing
-    "colSpacing" $watermarkConfig.colspacing
-    "fontSize" $watermarkConfig.fontsize
-    "fontFamily" $watermarkConfig.fontfamily
+    "rowSpacing" $watermarkConfig.rowSpacing
+    "colSpacing" $watermarkConfig.colSpacing
+    "fontSize" $watermarkConfig.fontSize
+    "fontFamily" $watermarkConfig.fontFamily
     | merge $watermarkConfig
   -}}
   {{- $config = dict "watermark" $watermarkConfig | merge $config -}}

--- a/layouts/_partials/assets.html
+++ b/layouts/_partials/assets.html
@@ -4,6 +4,7 @@
 {{- $fingerprint := .Site.Store.Get "fingerprint" -}}
 {{- $config := (.Store.Get "this").config -}}
 {{- $config = dict "version" (hugo.Store.Get "version") | merge $config -}}
+{{- $author := partial "function/get-author-map.html" .Params.author -}}
 
 {{- /* Search */ -}}
 {{- if .Site.Params.search | and .Site.Params.search.enable -}}
@@ -191,8 +192,18 @@
 {{- if eq .Site.Params.watermark.enable true -}}
   {{- $source := $cdn.cellWatermarkJS | default "lib/cell-watermark/watermark.min.js" -}}
   {{- dict "Source" $source "Fingerprint" $fingerprint "Defer" true | dict "Page" . "Data" | partial "store/script.html" -}}
-  {{- /* Hugo bug: case insensitive for `.Site.Params` */ -}}
-  {{- $config = dict "watermark" .Site.Params.watermark | merge $config -}}
+  {{- /* All the Params configurations are case insensitive since Hugo 0.18 */ -}}
+  {{- $watermarkConfig := .Site.Params.watermark | default dict -}}
+  {{- $watermarkConfig = dict
+    "appendTo" ".widgets"
+    "content" ($watermarkConfig.content | default $author.name | default .Site.Title)
+    "rowSpacing" $watermarkConfig.rowspacing
+    "colSpacing" $watermarkConfig.colspacing
+    "fontSize" $watermarkConfig.fontsize
+    "fontFamily" $watermarkConfig.fontfamily
+    | merge $watermarkConfig
+  -}}
+  {{- $config = dict "watermark" $watermarkConfig | merge $config -}}
 {{- end -}}
 
 {{- /* Content Decryption */ -}}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/hugo-fixit/FixIt/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New feature
- [ ] Other

### Description

All the Params configurations are case insensitive since Hugo 0.18.
