### PR TITLE
fix(tabs): improve tab shortcode rendering and restore sticky code header

### DIFF
--- a/apps/test/content/posts/tabs-comprehensive-test.md
+++ b/apps/test/content/posts/tabs-comprehensive-test.md
@@ -115,7 +115,7 @@ Nested tab C with a table:
 {{% tab title="Outer Tab 3" %}}
 This tab contains vertical nested tabs:
 
-{{< tabs type="card" vertical=true >}}
+{{< tabs type="card" placement="left" >}}
 
 {{% tab title="Vertical A" %}}
 Content for vertical nested tab A.

--- a/assets/scss/pages/single/shortcodes/_tabs.scss
+++ b/assets/scss/pages/single/shortcodes/_tabs.scss
@@ -76,7 +76,6 @@ tab-container {
   &[placement='left'],
   &[placement='right'] {
     max-width: 100%;
-    overflow: hidden;
 
     &::part(tablist-wrapper) {
       min-height: 100px;

--- a/layouts/_shortcodes/fixit-encryptor.html
+++ b/layouts/_shortcodes/fixit-encryptor.html
@@ -3,7 +3,7 @@
 
 {{- if $password -}}
   {{- /* Content */ -}}
-  {{- $content := .Inner | .Page.RenderString -}}
+  {{- $content := .Inner | strings.TrimSpace | .Page.RenderString -}}
   {{- /* Content Encryption */ -}}
   {{- dict "Content" $content "Password" $password "Message" $message "IsPartial" true "Page" .Page | partial "plugin/fixit-encryptor.html" -}}
   {{- .Page.Store.Set "hasEncryptor" true -}}

--- a/layouts/_shortcodes/tab.html
+++ b/layouts/_shortcodes/tab.html
@@ -9,10 +9,7 @@
 {{- $id := dict "Page" .Page | partial "function/id.html" -}}
 {{- $title := .Get "title" -}}
 {{- .Parent.Store.Add "tabs" (slice (dict "title" $title "id" $id)) -}}
-{{- $content := trim .Inner "\r\n" -}}
-{{- /* Remove p tags around complete tab-container structure */ -}}
-{{- $content = $content | replaceRE `<p>(<tab-container[^>]*>[\s\S]*?</button>)</p>` "$1" -}}
 
 {{- /* Tab panel */ -}}
-<div role="tabpanel" aria-labelledby="tab-{{ $id }}" class="tab-panel">{{ $content | safeHTML }}</div>
+<div role="tabpanel" aria-labelledby="tab-{{ $id }}" class="tab-panel">{{ .Inner | strings.TrimSpace | .Page.RenderString }}</div>
 {{- /* EOF */ -}}

--- a/layouts/_shortcodes/tabs.html
+++ b/layouts/_shortcodes/tabs.html
@@ -40,14 +40,16 @@
 {{- end -}}
 
 {{- /* Tabs Container */ -}}
-<tab-container default-tab="{{ $defaultTab }}" placement="{{ $placement }}"{{ with $type }} type="{{ . }}"{{ end }}>
-  {{- range $index, $tab := $tabs -}}
-    {{- $title := $tab.title | default (printf "Untitled%v" $index) -}}
-    {{- $id := $tab.id -}}
-    <button class="tab-button" type="button" role="tab" id="tab-{{ $id }}" aria-selected="{{ eq $index $defaultTab }}">{{ $title | $.Page.RenderString }}</button>
-  {{- end -}}
-  {{- .Inner -}}
-</tab-container>
+<div class="shortcode-tabs">
+  <tab-container default-tab="{{ $defaultTab }}" placement="{{ $placement }}"{{ with $type }} type="{{ . }}"{{ end }}>
+    {{- range $index, $tab := $tabs -}}
+      {{- $title := $tab.title | default (printf "Untitled%v" $index) -}}
+      {{- $id := $tab.id -}}
+      <button class="tab-button" type="button" role="tab" id="tab-{{ $id }}" aria-selected="{{ eq $index $defaultTab }}">{{ $title | $.Page.RenderString }}</button>
+    {{- end -}}
+    {{- .Inner | strings.TrimSpace | .Page.RenderString -}}
+  </tab-container>
+</div>
 
 {{- .Page.Store.Set "hasTabs" true -}}
 


### PR DESCRIPTION
<!--
Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guidelines](https://github.com/hugo-fixit/FixIt/blob/main/CONTRIBUTING.md).
- Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).
-->

### Description

Improve tab shortcode rendering and restore sticky code header.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New feature
- [ ] Other

