### PR TITLE
feat(assets): improve comment system config and lang mapping

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1683,6 +1683,7 @@ region = ""
 path = ""
 visitor = true
 commentCount = true
+lang = ""
 # FixIt 0.2.17 | CHANGED enable lightgallery support
 lightgallery = false
 # FixIt 0.2.17 | NEW enable Katex support

--- a/hugo.toml
+++ b/hugo.toml
@@ -1534,8 +1534,9 @@ enable = false
 enable = false
 server = "https://yourdomain"
 site = "默认站点"
-# FixIt 0.3.3 | NEW whether use backend configuration
-useBackendConf = false
+# FixIt 1.0.0 | NEW prefer remote (backend) configuration over local
+# If true, remote config takes priority; if false (default), local config overrides remote
+preferRemoteConf = false
 placeholder = ""
 noComment = ""
 sendBtn = ""
@@ -1543,8 +1544,7 @@ editorTravel = true
 flatMode = "auto"
 # FixIt 0.2.17 | CHANGED enable lightgallery support
 lightgallery = false
-locale = "" # FixIt 0.2.15 | NEW
-# FixIt 0.2.18 | NEW
+locale = ""
 emoticons = ""
 nestMax = 2
 nestSort = "DATE_ASC" # ["DATE_ASC", "DATE_DESC", "VOTE_UP_DESC"]
@@ -1552,9 +1552,27 @@ vote = true
 voteDown = false
 uaBadge = true
 listSort = true
+listUnreadHighlight = false
 imgUpload = true
+imgLazyLoad = false # false | "native" | "data-src"
 preview = true
 versionCheck = true
+# request timeout in milliseconds
+reqTimeout = 15000
+# page view increment on comment list load
+pvAdd = true
+
+# FixIt 1.0.0 | NEW pagination config
+[params.page.comment.artalk.pagination]
+pageSize = 20
+readMore = true
+autoLoad = true
+
+# FixIt 1.0.0 | NEW height limit config
+[params.page.comment.artalk.heightLimit]
+content = 300
+children = 400
+scrollable = false
 
 # Disqus comment config (https://disqus.com)
 [params.page.comment.disqus]

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -84,9 +84,7 @@ siteRunning = "Website läuft ..."
 
 # === Comment ===
 [comment]
-valineLang = "en" # Deutsch unterstützt Valine nicht
 valinePlaceholder = "Ihr Kommentar ..."
-facebookLanguageCode = "de_DE"
 # === Comment ===
 
 # === Assets ===

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -84,9 +84,7 @@ siteRunning = "Website running ..."
 
 # === Comment ===
 [comment]
-valineLang = "en"
 valinePlaceholder = "Your comment ..."
-facebookLanguageCode = "en_US"
 # === Comment ===
 
 # === Assets ===

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -84,9 +84,7 @@ siteRunning = "El sitio se está ejecutando ..."
 
 # === Comment ===
 [comment]
-valineLang = "en" # Español no soportado por Valine
 valinePlaceholder = "Tu comentario ..."
-facebookLanguageCode = "es_MX"
 # === Comment ===
 
 # === Assets ===

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -84,9 +84,7 @@ siteRunning = "Site en cours d'exécution ..."
 
 # === Comment ===
 [comment]
-valineLang = "en" # French not supported by Valine
 valinePlaceholder = "Votre commentaire ..."
-facebookLanguageCode = "fr"
 # === Comment ===
 
 # === Assets ===

--- a/i18n/hi.toml
+++ b/i18n/hi.toml
@@ -85,9 +85,7 @@ siteRunning = "वेबसाइट चल रही है ..."
 
 # === Comment ===
 [comment]
-valineLang = "hi"
 valinePlaceholder = "आपकी टिप्पणी ..."
-facebookLanguageCode = "hi"
 # === Comment ===
 
 # === Assets ===

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -84,9 +84,7 @@ siteRunning = "Sito in esecuzione ..."
 
 # === Comment ===
 [comment]
-valineLang = "en" # Valine non supporta l'italiano
 valinePlaceholder = "Il tuo commento ..."
-facebookLanguageCode = "it"
 # === Comment ===
 
 # === Assets ===

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -82,9 +82,7 @@ siteRunning = "サイトが実行中……"
 
 # === Comment ===
 [comment]
-valineLang = "zh-cn"
 valinePlaceholder = "あなたのコメント……"
-facebookLanguageCode = "zh_CN"
 # === Comment ===
 
 # === Assets ===

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -82,9 +82,7 @@ siteRunning = "사이트 운영 중……"
 
 # === Comment ===
 [comment]
-valineLang = "ko"
 valinePlaceholder = "당신의 댓글……"
-facebookLanguageCode = "ko_KR"
 # === Comment ===
 
 # === Assets ===

--- a/i18n/pl.toml
+++ b/i18n/pl.toml
@@ -84,9 +84,7 @@ siteRunning = "Website running ..."
 
 # === Comment ===
 [comment]
-valineLang = "en" # Valine nie obsługuje języka polskiego
 valinePlaceholder = "Twój komentarz ..."
-facebookLanguageCode = "pl"
 # === Comment ===
 
 # === Assets ===

--- a/i18n/pt-BR.toml
+++ b/i18n/pt-BR.toml
@@ -85,9 +85,7 @@ siteRunning = "Site no ar..."
 
 # === Comment ===
 [comment]
-valineLang = "en" # Valine não suporta português
 valinePlaceholder = "O seu comentário..."
-facebookLanguageCode = "pt_BR"
 # === Comment ===
 
 # === Assets ===

--- a/i18n/ro.toml
+++ b/i18n/ro.toml
@@ -84,9 +84,7 @@ siteRunning = "Site-ul rulează ..."
 
 # === Comment ===
 [comment]
-valineLang = "en" # Valine nu suporta romana
 valinePlaceholder = "Comentariul dvs ..."
-facebookLanguageCode = "ro_RO"
 # === Comment ===
 
 # === Assets ===

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -84,9 +84,7 @@ siteRunning = "Website running ..."
 
 # === Comment ===
 [comment]
-valineLang = "en" # Valine не поддерживает русский
 valinePlaceholder = "Ваш комментарий ..."
-facebookLanguageCode = "ru_RU"
 # === Comment ===
 
 # === Assets ===

--- a/i18n/sr.toml
+++ b/i18n/sr.toml
@@ -84,9 +84,7 @@ siteRunning = "Website running ..."
 
 # === Comment ===
 [comment]
-valineLang = "sr" # Valine не подржава српски
 valinePlaceholder = "Ваш коментар ..."
-facebookLanguageCode = "sr_RS"
 # === Comment ===
 
 # === Assets ===

--- a/i18n/vi.toml
+++ b/i18n/vi.toml
@@ -83,9 +83,7 @@ siteRunning = "Trang web đang chạy ..."
 
 # === Comment ===
 [comment]
-valineLang = "en" # Valine không hỗ trợ tiếng Việt
 valinePlaceholder = "Bình luận của bạn ..."
-facebookLanguageCode = "vi"
 # === Comment ===
 
 # === Assets ===

--- a/i18n/zh-CN.toml
+++ b/i18n/zh-CN.toml
@@ -82,9 +82,7 @@ siteRunning = "网站运行中……"
 
 # === Comment ===
 [comment]
-valineLang = "zh-cn"
 valinePlaceholder = "你的评论……"
-facebookLanguageCode = "zh_CN"
 # === Comment ===
 
 # === Assets ===

--- a/i18n/zh-TW.toml
+++ b/i18n/zh-TW.toml
@@ -82,9 +82,7 @@ siteRunning = "網站運行中……"
 
 # === Comment ===
 [comment]
-valineLang = "zh-TW"
 valinePlaceholder = "你的評論……"
-facebookLanguageCode = "zh-TW"
 # === Comment ===
 
 # === Assets ===

--- a/layouts/_partials/base/comment.html
+++ b/layouts/_partials/base/comment.html
@@ -310,14 +310,30 @@
     {{- end -}}
 
     {{- /* Twikoo Comment System */ -}}
-    {{- /* TODO review lang config https://github.com/twikoojs/twikoo/blob/main/src/client/utils/i18n/index.js */ -}}
     {{- $twikoo := $comment.twikoo | default dict -}}
     {{- if $twikoo.enable -}}
       <div id="twikoo"></div>
       {{- $source := $cdn.twikooJS | default "lib/twikoo/twikoo.all.min.js" -}}
       {{- dict "Source" $source "Fingerprint" $fingerprint "Defer" true | dict "Page" . "Data" | partial "store/script.html" -}}
       {{- dict "Source" "js/lib/twikoo.ts" "Build" true "Fingerprint" $fingerprint "Defer" true | dict "Page" . "Data" | partial "store/script.html" -}}
-      {{- $commentConfig = dict "el" "#twikoo" "envId" $twikoo.envId "lang" .Lang | dict "twikoo" | merge $commentConfig -}}
+      {{- /* Twikoo lang map: https://github.com/twikoojs/twikoo/blob/main/src/client/utils/i18n/index.js */ -}}
+      {{- $twikooLangMap := dict "pt-BR" "pt" "sr" "hr" -}}
+      {{- $lang := .Lang -}}
+      {{- with index $twikooLangMap $lang -}}
+        {{- $lang = . -}}
+      {{- else -}}
+        {{- $twikooLangs := slice "zh" "zh-cn" "zh-hk" "zh-tw" "en" "en-us" "en-gb" "uz" "ja" "ja-jp" "ko" "ko-kr" "vi" "vi-vn" -}}
+        {{- if not (in $twikooLangs $lang) -}}
+          {{- /* fallback to base language code, then "en" */ -}}
+          {{- $baseLang := index (split $lang "-") 0 -}}
+          {{- if in $twikooLangs $baseLang -}}
+            {{- $lang = $baseLang -}}
+          {{- else -}}
+            {{- $lang = "en" -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+      {{- $commentConfig = dict "el" "#twikoo" "envId" $twikoo.envId "lang" $lang | dict "twikoo" | merge $commentConfig -}}
       {{- with $twikoo.region -}}
         {{- $commentConfig = dict "region" . | dict "twikoo" | merge $commentConfig -}}
       {{- end -}}

--- a/layouts/_partials/base/comment.html
+++ b/layouts/_partials/base/comment.html
@@ -156,7 +156,11 @@
       {{- $source := $cdn.valineJS | default "lib/valine/Valine.min.js" -}}
       {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Page" . "Data" | partial "store/script.html" -}}
       {{- dict "Source" "js/lib/valine.ts" "Build" true "Fingerprint" $fingerprint "Defer" true | dict "Page" . "Data" | partial "store/script.html" -}}
-      {{- $commentConfig = dict "el" "#valine" "appId" $valine.appId "appKey" $valine.appKey "lang" ($valine.lang | default (T "valineLang")) "visitor" $valine.visitor "recordIP" $valine.recordIP "placeholder" ($valine.placeholder | default (T "comment.valinePlaceholder")) "highlight" (ne $valine.highlight false) "enableQQ" $valine.enableQQ | dict "valine" | merge $commentConfig -}}
+      {{- /* Valine lang: https://github.com/xCss/Valine */ -}}
+      {{- $valineLang := $valine.lang | default .Lang -}}
+      {{- $valineLangs := dict "zh-cn" "zh-cn" "zh-tw" "zh-tw" "en" "en" "en-us" "en" "en-gb" "en" "ja" "ja" "ko" "ko" "ru" "ru" "fr" "fr" "pt-br" "pt" -}}
+      {{- $valineLang = or (index $valineLangs $valineLang) (index $valineLangs (index (split $valineLang "-") 0)) "en" -}}
+      {{- $commentConfig = dict "el" "#valine" "appId" $valine.appId "appKey" $valine.appKey "lang" $valineLang "visitor" $valine.visitor "recordIP" $valine.recordIP "placeholder" ($valine.placeholder | default (T "comment.valinePlaceholder")) "highlight" (ne $valine.highlight false) "enableQQ" $valine.enableQQ | dict "valine" | merge $commentConfig -}}
       {{- with $valine.avatar -}}
         {{- $commentConfig = dict "avatar" . | dict "valine" | merge $commentConfig -}}
       {{- end -}}
@@ -250,7 +254,11 @@
         data-width="{{ $facebook.width }}"
         data-numposts="{{ $facebook.numPosts }}"
       ></div>
-      {{- $source := printf "https://connect.facebook.net/%v/sdk.js#xfbml=1&version=v5.0&appId=%v&autoLogAppEvents=1" ($facebook.languageCode | default (T "comment.facebookLanguageCode")) $facebook.appId -}}
+      {{- /* Facebook locale: https://developers.facebook.com/docs/internationalization */ -}}
+      {{- $fbLang := $facebook.languageCode | default .Lang -}}
+      {{- $fbLangs := dict "zh" "zh_CN" "zh-cn" "zh_CN" "zh-tw" "zh_TW" "en" "en_US" "ja" "ja_JP" "ko" "ko_KR" "fr" "fr_FR" "de" "de_DE" "es" "es_ES" "pt" "pt_BR" "pt-br" "pt_BR" "ru" "ru_RU" "it" "it_IT" "hi" "hi_IN" "pl" "pl_PL" "ro" "ro_RO" "sr" "sr_RS" "vi" "vi_VN" -}}
+      {{- $fbLang = or (index $fbLangs $fbLang) (index $fbLangs (index (split $fbLang "-") 0)) "en_US" -}}
+      {{- $source := printf "https://connect.facebook.net/%v/sdk.js#xfbml=1&version=v5.0&appId=%v&autoLogAppEvents=1" $fbLang $facebook.appId -}}
       {{- dict "Source" $source "Defer" true | dict "Page" . "Data" | partial "store/script.html" -}}
       <noscript>
         Please enable JavaScript to view the comments powered by <a href="https://developers.facebook.com/docs/plugins/comments/" rel="external nofollow noopener noreferrer">Facebook</a>.
@@ -316,23 +324,11 @@
       {{- $source := $cdn.twikooJS | default "lib/twikoo/twikoo.all.min.js" -}}
       {{- dict "Source" $source "Fingerprint" $fingerprint "Defer" true | dict "Page" . "Data" | partial "store/script.html" -}}
       {{- dict "Source" "js/lib/twikoo.ts" "Build" true "Fingerprint" $fingerprint "Defer" true | dict "Page" . "Data" | partial "store/script.html" -}}
-      {{- /* Twikoo lang map: https://github.com/twikoojs/twikoo/blob/main/src/client/utils/i18n/index.js */ -}}
-      {{- $twikooLangMap := dict "pt-BR" "pt" "sr" "hr" -}}
-      {{- $lang := .Lang -}}
-      {{- with index $twikooLangMap $lang -}}
-        {{- $lang = . -}}
-      {{- else -}}
-        {{- $twikooLangs := slice "zh" "zh-cn" "zh-hk" "zh-tw" "en" "en-us" "en-gb" "uz" "ja" "ja-jp" "ko" "ko-kr" "vi" "vi-vn" -}}
-        {{- if not (in $twikooLangs $lang) -}}
-          {{- /* fallback to base language code, then "en" */ -}}
-          {{- $baseLang := index (split $lang "-") 0 -}}
-          {{- if in $twikooLangs $baseLang -}}
-            {{- $lang = $baseLang -}}
-          {{- else -}}
-            {{- $lang = "en" -}}
-          {{- end -}}
-        {{- end -}}
-      {{- end -}}
+      {{- /* Twikoo lang: https://github.com/twikoojs/twikoo/blob/main/src/client/utils/i18n/index.js */ -}}
+      {{- $lang := $twikoo.lang | default .Lang -}}
+      {{- $langs := slice "zh" "zh-cn" "zh-hk" "zh-tw" "en" "en-us" "en-gb" "uz" "ja" "ja-jp" "ko" "ko-kr" "vi" "vi-vn" "pt" "hr" -}}
+      {{- $base := index (split $lang "-") 0 -}}
+      {{- $lang = or (and (in $langs $lang) $lang) (and (in $langs $base) $base) "en" -}}
       {{- $commentConfig = dict "el" "#twikoo" "envId" $twikoo.envId "lang" $lang | dict "twikoo" | merge $commentConfig -}}
       {{- with $twikoo.region -}}
         {{- $commentConfig = dict "region" . | dict "twikoo" | merge $commentConfig -}}

--- a/layouts/_partials/base/comment.html
+++ b/layouts/_partials/base/comment.html
@@ -7,11 +7,6 @@
   {{- $commentConfig = dict "enable" true "expired" (.Store.Get "commentExpired" | default false) -}}
   <div id="comments">
     {{- /* Artalk Comment System */ -}}
-    {{/*
-      TODO next version to support new config for Artalk
-      https://artalk.js.org/guide/frontend/config.html#评论分页
-      https://artalk.js.org/guide/frontend/config.html#内容限高
-    */}}
     {{- $artalk := $comment.artalk | default dict -}}
     {{- if $artalk.enable -}}
       <div id="artalk" class="comment"></div>
@@ -25,9 +20,6 @@
         {{- $artalk = dict "locale" "en-US" | merge $artalk -}}
       {{- end -}}
       {{- $commentConfig = dict "locale" ($artalk.locale | default $.Site.Language.Locale | default "auto") | dict "artalk" | merge $commentConfig -}}
-      {{- if eq $artalk.usebackendconf false -}}
-        {{- $commentConfig = dict "useBackendConf" false | dict "artalk" | merge $commentConfig -}}
-      {{- end -}}
       {{- with .Site.Params.gravatar -}}
         {{/* See https://artalk.js.org/guide/frontend/config.html#gravatar-params */}}
         {{- $gravatarMirror := printf "https://%v/avatar/" .Host -}}
@@ -83,6 +75,47 @@
       {{- end -}}
       {{- if eq $artalk.versioncheck false -}}
         {{- $commentConfig = dict "versionCheck" false | dict "artalk" | merge $commentConfig -}}
+      {{- end -}}
+      {{- if eq $artalk.preferremoteconf true -}}
+        {{- $commentConfig = dict "preferRemoteConf" true | dict "artalk" | merge $commentConfig -}}
+      {{- end -}}
+      {{- with $artalk.imglazyload -}}
+        {{- $commentConfig = dict "imgLazyLoad" . | dict "artalk" | merge $commentConfig -}}
+      {{- end -}}
+      {{- with $artalk.reqtimeout -}}
+        {{- $commentConfig = dict "reqTimeout" . | dict "artalk" | merge $commentConfig -}}
+      {{- end -}}
+      {{- if eq $artalk.listunreadhighlight true -}}
+        {{- $commentConfig = dict "listUnreadHighlight" true | dict "artalk" | merge $commentConfig -}}
+      {{- end -}}
+      {{- if eq $artalk.pvadd false -}}
+        {{- $commentConfig = dict "pvAdd" false | dict "artalk" | merge $commentConfig -}}
+      {{- end -}}
+      {{- with $artalk.pagination -}}
+        {{- $pagination := dict -}}
+        {{- with .pagesize -}}
+          {{- $pagination = dict "pageSize" . | merge $pagination -}}
+        {{- end -}}
+        {{- if eq .readmore false -}}
+          {{- $pagination = dict "readMore" false | merge $pagination -}}
+        {{- end -}}
+        {{- if eq .autoload false -}}
+          {{- $pagination = dict "autoLoad" false | merge $pagination -}}
+        {{- end -}}
+        {{- $commentConfig = dict "pagination" $pagination | dict "artalk" | merge $commentConfig -}}
+      {{- end -}}
+      {{- with $artalk.heightlimit -}}
+        {{- $heightLimit := dict -}}
+        {{- with .content -}}
+          {{- $heightLimit = dict "content" . | merge $heightLimit -}}
+        {{- end -}}
+        {{- with .children -}}
+          {{- $heightLimit = dict "children" . | merge $heightLimit -}}
+        {{- end -}}
+        {{- if eq .scrollable true -}}
+          {{- $heightLimit = dict "scrollable" true | merge $heightLimit -}}
+        {{- end -}}
+        {{- $commentConfig = dict "heightLimit" $heightLimit | dict "artalk" | merge $commentConfig -}}
       {{- end -}}
       <noscript>
         Please enable JavaScript to view the comments powered by <a href="https://github.com/ArtalkJS/Artalk" rel="external nofollow noopener noreferrer">Artalk</a>.


### PR DESCRIPTION
## Summary

- **Artalk**: add missing config options (`preferRemoteConf`, `pagination`, `heightLimit`, `imgLazyLoad`, `reqTimeout`, `listUnreadHighlight`, `pvAdd`), remove deprecated `useBackendConf`
- **Twikoo**: add `lang` config option with inline i18n mapping, add source link comment, simplify lang fallback logic
- **Valine**: replace i18n-based `valineLang` with inline mapping, fix `ja` incorrectly mapped to `zh-cn`
- **Facebook**: replace i18n-based `facebookLanguageCode` with inline locale mapping
- **i18n**: remove `valineLang` and `facebookLanguageCode` from all 16 language files (now handled in template)

## Test plan

- [x] Verify Artalk new config options work (pagination, heightLimit, etc.)
- [x] Verify Twikoo lang fallback: unsupported languages fall back to `en`
- [x] Verify Valine lang: `ja` correctly maps to `ja` (not `zh-cn`)
- [x] Verify Facebook locale codes are correct
- [x] `pnpm build:demo` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)