### PR TITLE
fix(scss): preserve mobile search modal height

### DIFF
--- a/assets/scss/widgets/_search-modal.scss
+++ b/assets/scss/widgets/_search-modal.scss
@@ -346,6 +346,7 @@ dialog.search-dialog {
     &:modal {
       inset: 0;
       width: 100%;
+      height: 100dvh;
       max-width: 100%;
       max-height: 100dvh;
       translate: 0 0;


### PR DESCRIPTION
## Summary

Fixes the mobile search dialog sizing regression reported in #826 by giving the dialog a definite viewport height on the xs breakpoint before the nested .search-modal percentage height resolves.

## Changes

- Added height: 100dvh to the mobile dialog sizing rule in assets/scss/widgets/_search-modal.scss
- Kept the existing full-screen modal behavior intact while preserving the nested modal height calculation

## Verification

- pnpm build:demo passed successfully after the fix

## Related issue

- Fixes #826