### PR TITLE
feat(layouts): add nav-dialog with tab switching for TOC and collections

### DIFF
--- a/assets/js/modules/toc.ts
+++ b/assets/js/modules/toc.ts
@@ -150,7 +150,7 @@ export class TocModule implements TocService {
           this.#scrollActiveTocLinkIntoView($autoTocRoot, activeId, $autoTocContainer)
         }
       }
-      if ((document.getElementById('toc-dialog') as HTMLDialogElement)?.open) {
+      if ((document.getElementById('nav-dialog') as HTMLDialogElement)?.open) {
         const $dialogTocRoot = document.querySelector<HTMLElement>('#toc-content-drawer > nav')!
         this.#scrollActiveTocLinkIntoView($dialogTocRoot, activeId, $dialogTocRoot)
       }
@@ -159,7 +159,7 @@ export class TocModule implements TocService {
 
   /** Sync TOC layout state: drawer button visibility, height, and active heading. */
   #syncTocLayout() {
-    document.querySelector<HTMLElement>('#toc-drawer-button')?.classList.toggle('hidden', !isTocStatic())
+    document.querySelector<HTMLElement>('#nav-drawer-button')?.classList.toggle('hidden', !isTocStatic())
     this.#activeTocId = null
     this.syncTocHeight()
     this.syncTocActiveState()
@@ -204,7 +204,7 @@ export class TocModule implements TocService {
 
   /** Initialize the mobile TOC drawer dialog and its open/close handlers. */
   #initTocDrawerLinkClose() {
-    const dialog = document.querySelector<HTMLDialogElement>('#toc-dialog')
+    const dialog = document.querySelector<HTMLDialogElement>('#nav-dialog')
     if (!dialog)
       return
     document.querySelectorAll<HTMLAnchorElement>('#toc-content-drawer a[href^="#"]').forEach(($link) => {
@@ -217,11 +217,11 @@ export class TocModule implements TocService {
 
   /** Initialize the mobile TOC drawer dialog and its open/close handlers. */
   #initTocDrawer() {
-    const dialog = document.querySelector<HTMLDialogElement>('#toc-dialog')
-    const openButton = document.querySelector<HTMLElement>('#toc-drawer-button')
+    const dialog = document.querySelector<HTMLDialogElement>('#nav-dialog')
+    const openButton = document.querySelector<HTMLElement>('#nav-drawer-button')
     if (!dialog || !openButton)
       return
-    const closeButton = dialog.querySelector<HTMLElement>('.toc-close-btn')
+    const closeButton = dialog.querySelector<HTMLElement>('.nav-close-btn')
     closeButton?.addEventListener('click', () => dialog.close())
     openButton.addEventListener('click', () => {
       dialog.showModal()

--- a/assets/scss/pages/posts/_collections.scss
+++ b/assets/scss/pages/posts/_collections.scss
@@ -108,7 +108,7 @@
 
   &.open {
     .collection-summary {
-      background-color: light-dark(color.adjust($global-background-color, $lightness: -5%), color.adjust($global-background-color-dark, $lightness: 5%));
+      background-color: light-dark(color.adjust($global-background-color, $lightness: -4%), color.adjust($global-background-color-dark, $lightness: 4%));
     }
   }
 
@@ -118,7 +118,8 @@
     gap: 0.25em;
     padding: 0.2em 0.5em;
     user-select: none;
-    background-color: light-dark(color.adjust($global-background-color, $lightness: -5%), color.adjust($global-background-color-dark, $lightness: 5%));
+    background-color: light-dark(color.adjust($global-background-color, $lightness: -4.5%), color.adjust($global-background-color-dark, $lightness: 4.5%));
+    transition: background-color 0.2s ease;
 
     > i.fa-layer-group {
       flex-shrink: 0;
@@ -183,7 +184,6 @@
       align-items: center;
       justify-content: center;
       gap: 0.5em;
-      background-color: light-dark(color.adjust($global-background-color, $lightness: -5%), color.adjust($global-background-color-dark, $lightness: 5%));
 
       [dir="rtl"] & i {
         scale: -1 1;

--- a/assets/scss/pages/posts/_toc.scss
+++ b/assets/scss/pages/posts/_toc.scss
@@ -63,7 +63,7 @@
 
 // Common active state styles for auto and dialog TOC
 #toc-auto,
-#toc-dialog {
+#nav-dialog {
   .toc-content {
     li.has-active {
       &::marker {
@@ -222,7 +222,7 @@
   }
 }
 
-#toc-dialog {
+#nav-dialog {
   opacity: 0;
   translate: 100vw 0;
   width: MIN(calc(100% - 4rem), 460px);
@@ -243,7 +243,7 @@
     translate: -100vw 0;
   }
 
-  .toc-close-btn {
+  .nav-close-btn {
     position: absolute;
     top: 1.25rem;
     inset-inline-end: 1rem;
@@ -263,18 +263,31 @@
     margin-inline: 1rem;
 
     .toc-title {
-      font-size: calc(#{fi-var(toc-title-font-size)} * 1.5);
-      line-height: calc(#{fi-var(toc-title-font-size)} * 2);
-      margin-block: fi-var(toc-title-font-size);
+      font-size: 1.25rem;
+      line-height: 2rem;
+      margin-block: 1rem 0.75rem;
     }
 
-    .toc-content {
-      font-size: MAX(fi-var(toc-content-font-size), 1rem);
+    // toc and collection tabs in dialog
+    > tab-container {
+      flex-direction: column;
+      margin-block: 0;
 
-      nav {
-        max-height: calc(100dvh - 5rem);
+      > .tab-button {
+        padding: 0.5rem;
+      }
+
+      > .tab-panel {
+        max-height: calc(100dvh - 8rem);
         overflow: auto;
       }
+    }
+
+    // only toc-content or collection-content in dialog
+    > .toc-content,
+    > .collection-content {
+      max-height: calc(100dvh - 5rem);
+      overflow: auto;
     }
   }
 

--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -124,6 +124,7 @@ other = "مشاركة على"
 # === Single Post ===
 [single]
 contents = "المحتويات"
+navigation = "التنقل"
 disclaimer = "تنبيه: "
 pin = "تثبيت في الأعلى"
 repost = "إعادة النشر"

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -123,6 +123,7 @@ other = "Teilen auf"
 # === Single Post ===
 [single]
 contents = "Inhalt"
+navigation = "Navigation"
 disclaimer = "Autorenhinweis: "
 pin = "Oben anheften"
 repost = "Erneut posten"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -123,6 +123,7 @@ other = "Share on"
 # === Single Post ===
 [single]
 contents = "Contents"
+navigation = "Navigation"
 disclaimer = "Disclaimer: "
 pin = "Pin to top"
 repost = "Repost"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -123,6 +123,7 @@ other = "Compartir en"
 # === Single Post ===
 [single]
 contents = "Contenido"
+navigation = "Navegación"
 disclaimer = "Aviso: "
 pin = "Fijar en la parte superior"
 repost = "Repostear"

--- a/i18n/fa.toml
+++ b/i18n/fa.toml
@@ -124,6 +124,7 @@ other = "اشتراک‌گذاری در"
 # === Single Post ===
 [single]
 contents = "فهرست مطالب"
+navigation = "ناوبری"
 disclaimer = "بیانیه نویسنده: "
 pin = "سنجاق کردن به بالا"
 repost = "بازنشر"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -123,6 +123,7 @@ other = "Partager via"
 # === Single Post ===
 [single]
 contents = "Contenus"
+navigation = "Navigation"
 disclaimer = "Avertissement : "
 pin = "Épingler en haut"
 repost = "Reposter"

--- a/i18n/hi.toml
+++ b/i18n/hi.toml
@@ -124,6 +124,7 @@ other = " शेयर करें"
 # === Single Post ===
 [single]
 contents = "सामग्री"
+navigation = "नेविगेशन"
 disclaimer = "लेखक का बयान: "
 pin = "शीर्ष पर पिन करें"
 repost = "दोबारा पोस्ट करें"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -123,6 +123,7 @@ other = "Condividi su"
 # === Single Post ===
 [single]
 contents = "Contenuti"
+navigation = "Navigazione"
 disclaimer = "Avvertenza: "
 pin = "Fissa in alto"
 repost = "Ripubblica"

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -121,6 +121,7 @@ other = "共有先"
 # === Single Post ===
 [single]
 contents = "目次"
+navigation = "ナビゲーション"
 disclaimer = "著者声明："
 pin = "ピン留め"
 repost = "再投稿"

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -121,6 +121,7 @@ other = "공유하기"
 # === Single Post ===
 [single]
 contents = "목차"
+navigation = "내비게이션"
 disclaimer = "작성자 성명: "
 pin = "고정"
 repost = "재게시"

--- a/i18n/pl.toml
+++ b/i18n/pl.toml
@@ -123,6 +123,7 @@ other = "Udostępnij na"
 # === Single Post ===
 [single]
 contents = "Spis treści"
+navigation = "Nawigacja"
 disclaimer = "Ostrzeżenie: "
 pin = "Przypnij na górze"
 repost = "Prześlij ponownie"

--- a/i18n/pt-BR.toml
+++ b/i18n/pt-BR.toml
@@ -124,6 +124,7 @@ other = "Compartilhar em"
 # === Single Post ===
 [single]
 contents = "Conteúdos"
+navigation = "Navegação"
 disclaimer = "Aviso: "
 pin = "Fixar no topo"
 repost = "Repostar"

--- a/i18n/ro.toml
+++ b/i18n/ro.toml
@@ -123,6 +123,7 @@ other = "Distribuie pe"
 # === Single Post ===
 [single]
 contents = "Cuprins"
+navigation = "Navigare"
 disclaimer = "Notificare: "
 pin = "Fixează în partea de sus"
 repost = "Repostează"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -123,6 +123,7 @@ other = "Поделиться в"
 # === Single Post ===
 [single]
 contents = "Содержание"
+navigation = "Навигация"
 disclaimer = "Заявление автора: "
 pin = "Закрепить наверху"
 repost = "Перепостить"

--- a/i18n/sr.toml
+++ b/i18n/sr.toml
@@ -123,6 +123,7 @@ other = "Подели на"
 # === Single Post ===
 [single]
 contents = "Садржаји"
+navigation = "Навигација"
 disclaimer = "Obavetenje: "
 pin = "Закачи"
 repost = "Поново објави"

--- a/i18n/ur.toml
+++ b/i18n/ur.toml
@@ -124,6 +124,7 @@ other = "پر شیئر کریں"
 # === Single Post ===
 [single]
 contents = "مواد"
+navigation = "نیویگیشن"
 disclaimer = "Tafheem: "
 pin = "اوپر پن کریں"
 repost = "دوبارہ شائع کریں"

--- a/i18n/vi.toml
+++ b/i18n/vi.toml
@@ -122,6 +122,7 @@ other = "Chia sẻ trên"
 # === Single Post ===
 [single]
 contents = "Nội dung"
+navigation = "Điều hướng"
 disclaimer = "Tuyên bố của tác giả: "
 pin = "Ghim ở đầu trang"
 repost = "Đăng lại"

--- a/i18n/zh-CN.toml
+++ b/i18n/zh-CN.toml
@@ -121,6 +121,7 @@ other = "分享到"
 # === Single Post ===
 [single]
 contents = "目录"
+navigation = "导航"
 disclaimer = "作者声明："
 pin = "置顶"
 repost = "转载"

--- a/i18n/zh-TW.toml
+++ b/i18n/zh-TW.toml
@@ -121,6 +121,7 @@ other = "分享到"
 # === Single Post ===
 [single]
 contents = "目錄"
+navigation = "導航"
 disclaimer = "作者聲明："
 pin = "置頂"
 repost = "轉貼"

--- a/layouts/_partials/base/widgets.html
+++ b/layouts/_partials/base/widgets.html
@@ -2,49 +2,20 @@
   Global widget layer partial.
 
   Renders floating UI elements across all pages:
-  - Fixed action buttons (back-to-top, TOC drawer, view comments)
   - GitHub corner link
+  - Navigation dialog
   - Search dialog modal
   - Reading progress bar
   - Link guard confirmation dialog
   - Service worker update notification
+  - Fixed action buttons (back-to-top, TOC drawer, view comments)
+  - Custom widgets
   - Noscript warning
 
   Called from: layouts/baseof.html.
 */ -}}
 
 <div class="widgets">
-  {{- $backToTop := .Site.Params.back_to_top -}}
-  {{- $comment := .Store.Get "comment" -}}
-  {{- if $backToTop.enable | or $comment.enable -}}
-    <div class="fixed-buttons">
-      {{- /* back to top button */ -}}
-      {{- if $backToTop.enable -}}
-        <button type="button" class="fixed-button back-to-top animate__faster hidden" aria-label="{{ T `baseof.backToTop` }}">
-          {{- dict "Class" "fa-solid fa-arrow-up" | partial "plugin/icon.html" -}}
-          {{- if $backToTop.scrollpercent -}}
-            <svg viewBox="0 0 100 100">
-              <circle class="bg" cx="50" cy="50" r="50"></circle>
-              <circle class="progress" cx="50" cy="50" r="50"></circle>
-            </svg>
-          {{- end -}}
-        </button>
-      {{- end -}}
-      {{- /* toc dialog button */ -}}
-      {{- if .Store.Get "showToc" -}}
-        <button type="button" id="toc-drawer-button" class="fixed-button toc-drawer-button hidden{{ with .Params.password }} encrypted-hidden{{ end }}" aria-label="{{ T `single.contents` }}" aria-controls="toc-dialog" aria-expanded="false">
-          {{- dict "Class" "fa-solid fa-bars" | partial "plugin/icon.html" -}}
-        </button>
-      {{- end -}}
-      {{- /* comment button */ -}}
-      {{- if $comment.enable -}}
-        <button type="button" class="fixed-button view-comments hidden" aria-label="{{ T `baseof.viewComments` }}">
-          {{- dict "Class" "fa-solid fa-comment" | partial "plugin/icon.html" -}}
-        </button>
-      {{- end -}}
-    </div>
-  {{- end -}}
-
   {{- /* GitHub Corners */ -}}
   {{- $githubCorner := .Site.Params.github_corner -}}
   {{- if $githubCorner.enable -}}
@@ -58,6 +29,9 @@
 
   {{- /* Header mobile mask */ -}}
   <div id="mask"></div>
+
+  {{- /* Nav Dialog */ -}}
+  {{- partial "single/nav-dialog.html" . -}}
 
   {{- /* Search dialog */ -}}
   {{- if .Site.Params.search.enable -}}
@@ -152,6 +126,37 @@
         <p class="sw-update-text">{{ T "serviceWorker.updateText" }}</p>
       </div>
       <button type="button" class="sw-update-btn">{{ T "assets.refresh" }}</button>
+    </div>
+  {{- end -}}
+
+  {{- $backToTop := .Site.Params.back_to_top -}}
+  {{- $comment := .Store.Get "comment" -}}
+  {{- if $backToTop.enable | or $comment.enable -}}
+    <div class="fixed-buttons">
+      {{- /* back to top button */ -}}
+      {{- if $backToTop.enable -}}
+        <button type="button" class="fixed-button back-to-top animate__faster hidden" aria-label="{{ T `baseof.backToTop` }}">
+          {{- dict "Class" "fa-solid fa-arrow-up" | partial "plugin/icon.html" -}}
+          {{- if $backToTop.scrollpercent -}}
+            <svg viewBox="0 0 100 100">
+              <circle class="bg" cx="50" cy="50" r="50"></circle>
+              <circle class="progress" cx="50" cy="50" r="50"></circle>
+            </svg>
+          {{- end -}}
+        </button>
+      {{- end -}}
+      {{- /* nav dialog button */ -}}
+      {{- if .Store.Get "showNavDialog" -}}
+        <button type="button" id="nav-drawer-button" class="fixed-button nav-drawer-button hidden{{ with .Params.password }} encrypted-hidden{{ end }}" aria-label="{{ T `single.navigation` }}" aria-controls="nav-dialog" aria-expanded="false">
+          {{- dict "Class" "fa-solid fa-bars" | partial "plugin/icon.html" -}}
+        </button>
+      {{- end -}}
+      {{- /* comment button */ -}}
+      {{- if $comment.enable -}}
+        <button type="button" class="fixed-button view-comments hidden" aria-label="{{ T `baseof.viewComments` }}">
+          {{- dict "Class" "fa-solid fa-comment" | partial "plugin/icon.html" -}}
+        </button>
+      {{- end -}}
     </div>
   {{- end -}}
 

--- a/layouts/_partials/single/collection-list.html
+++ b/layouts/_partials/single/collection-list.html
@@ -5,9 +5,6 @@
     {{- $pages := (where .Pages "Params.Weight" "!=" nil) | append (where .Pages "Params.Weight" "eq" nil).ByDate -}}
     {{- $open := eq (index $collectionTerms 0) . -}}
     {{- $currentKey := 0 -}}
-    {{- if lt $pages.Len 2 -}}
-      {{- continue -}}
-    {{- end -}}
     <div class="details collection-details{{ if $open }} open{{ end }}">
       <div class="details-summary collection-summary">
         {{ dict "Class" "fa-solid fa-layer-group" | partial "plugin/icon.html" }}

--- a/layouts/_partials/single/nav-dialog.html
+++ b/layouts/_partials/single/nav-dialog.html
@@ -1,0 +1,34 @@
+{{- /* Nav Dialog - Mobile drawer for TOC and Collections */ -}}
+{{- $showToc := .Store.Get "showToc" -}}
+{{- $showCollection := .Params.collections | and (.Param "collection_list") -}}
+{{- $showNavDialog := $showToc | or $showCollection -}}
+{{- .Store.Set "showNavDialog" $showNavDialog -}}
+{{- if $showNavDialog -}}
+  <dialog id="nav-dialog" aria-labelledby="nav-dialog-title" closedby="any">
+    <button type="button" class="nav-close-btn" aria-label="Close {{ T `single.navigation` }}">
+      {{- dict "Class" "fa-solid fa-xmark fa-lg" | partial "plugin/icon.html" -}}
+    </button>
+    <div class="toc">
+      <h2 class="toc-title" id="nav-dialog-title">{{ T "single.navigation" }}</h2>
+      {{- if $showToc | and $showCollection -}}
+        {{- .Store.Set "hasTabs" true -}}
+        <tab-container type="segment">
+          <button class="tab-button" type="button" role="tab" aria-selected="true">{{ T "single.contents" }}</button>
+          <button class="tab-button" type="button" role="tab" aria-selected="false">{{ T "collections" }}</button>
+          <div role="tabpanel" class="tab-panel">
+            <div class="toc-content" id="toc-content-drawer"></div>
+          </div>
+          <div role="tabpanel" class="tab-panel" hidden>
+            {{- partial "single/collection-list.html" . -}}
+          </div>
+        </tab-container>
+      {{- else if $showToc -}}
+        <div class="toc-content" id="toc-content-drawer"></div>
+      {{- else -}}
+        <div class="collection-content">
+          {{- partial "single/collection-list.html" . -}}
+        </div>
+      {{- end -}}
+    </div>
+  </dialog>
+{{- end -}}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -244,19 +244,6 @@
     {{- /* Custom block after post toc */ -}}
     {{- block "custom-post__toc:after" . }}{{ end -}}
   </aside>
-
-  {{- /* TOC Dialog */ -}}
-  {{- if $showToc -}}
-    <dialog id="toc-dialog" aria-labelledby="toc-dialog-title" closedby="any">
-      <button type="button" class="toc-close-btn" aria-label="Close Table of Contents">
-        {{- dict "Class" "fa-solid fa-xmark fa-lg" | partial "plugin/icon.html" -}}
-      </button>
-      <div class="toc">
-        <h2 class="toc-title" id="toc-dialog-title">{{ T "single.contents" }}</h2>
-        <div class="toc-content" id="toc-content-drawer"></div>
-      </div>
-    </dialog>
-  {{- end -}}
 {{- end -}}
 
 {{- define "comments" -}}


### PR DESCRIPTION
## Summary

- Rename `toc-dialog` to `nav-dialog`，移动端抽屉不再仅限目录，同时支持合集列表
- 使用 `<tab-container>` (tab-element) 实现目录/合集 tab 切换
- 抽取 `nav-dialog.html` 独立 partial，从 widgets.html 渲染
- 新增 `single.navigation` i18n 键（"导航"/"Navigation" 等 19 种语言）
- 仅有合集（无目录）时也能显示 nav-drawer-button

## Changes

| File | Change |
|------|--------|
| `layouts/_partials/single/nav-dialog.html` | 新建，nav-dialog 组件 |
| `layouts/posts/single.html` | 移除内联 toc-dialog 模板 |
| `layouts/_partials/base/widgets.html` | 按钮条件改为 `showNavDialog`，dialog 移入 |
| `assets/js/modules/toc.ts` | 所有 `toc-dialog` 引用改为 `nav-dialog` |
| `assets/scss/pages/posts/_toc.scss` | `#toc-dialog` → `#nav-dialog`，新增 tab/collection 样式 |
| `i18n/*.toml` | 新增 `single.navigation` 翻译 |

## Test plan

- [x] 打开属于合集的文章，<=960px 视口下点击浮动按钮
- [x] 验证目录/合集 tab 切换正常
- [x] 验证目录链接点击后 dialog 关闭
- [x] 验证合集链接正常导航
- [x] 验证仅有目录（无合集）时无 tab，直接显示目录
- [x] 验证 RTL 布局表现