### PR TITLE
feat(layouts): add sort toggle for collection list

### DIFF
--- a/assets/js/core/tokens.ts
+++ b/assets/js/core/tokens.ts
@@ -61,6 +61,7 @@ export interface EncryptionService {
 export interface ContentService {
   initSVGIcon: () => void
   initLinkGuardDialog: (target?: Element | Document) => void
+  initCollectionSort: () => void
   initContent: (target?: Element | Document) => void
   setup: () => void
 }

--- a/assets/js/modules/content.ts
+++ b/assets/js/modules/content.ts
@@ -126,6 +126,94 @@ export class ContentModule implements ContentService {
     })
   }
 
+  /** Initialize collection sort toggle buttons. */
+  initCollectionSort() {
+    document.querySelectorAll<HTMLButtonElement>('.collection-sort-toggle').forEach(($btn) => {
+      if ($btn.dataset.init)
+        return
+      $btn.dataset.init = 'true'
+
+      const $details = $btn.closest('.collection-details')
+      const $list = $details?.querySelector<HTMLUListElement>('.collection-list')
+      const $nav = $details?.querySelector<HTMLElement>('.collection-nav-simple')
+      if (!$list || !$nav)
+        return
+
+      let isAsc = true
+
+      $btn.addEventListener('click', (e) => {
+        e.stopPropagation()
+        isAsc = !isAsc
+
+        // Reverse list items
+        Array.from($list.children).reverse().forEach(el => $list.appendChild(el))
+
+        // Toggle icon
+        const $icon = $btn.querySelector<HTMLElement>('i')
+        if ($icon) {
+          $icon.classList.toggle('fa-arrow-down-wide-short', !isAsc)
+          $icon.classList.toggle('fa-arrow-up-short-wide', isAsc)
+        }
+
+        // Find active item and update nav from its siblings
+        const $items = Array.from($list.children)
+        const $active = $list.querySelector('.active')
+        const activeIdx = $active ? $items.indexOf($active.closest('li')!) : -1
+
+        // Update counter
+        const $counter = $nav.querySelector<HTMLElement>('.text-secondary:not(.collection-nav-item)')
+        if ($counter && activeIdx >= 0) {
+          $counter.textContent = `${activeIdx + 1}/${$items.length}`
+        }
+
+        // Update prev link (left arrow)
+        const $navItems = $nav.querySelectorAll<HTMLElement>('.collection-nav-item')
+        const $prevItem = activeIdx > 0 ? $items[activeIdx - 1].querySelector('a') : null
+        if ($navItems[0]) {
+          if ($prevItem) {
+            const $link = document.createElement('a')
+            $link.href = $prevItem.href
+            $link.className = 'collection-nav-item'
+            $link.rel = 'prev'
+            $link.title = $prevItem.title || ''
+            const $i = document.createElement('i')
+            $i.className = 'fa-solid fa-angle-left'
+            $link.appendChild($i)
+            $navItems[0].replaceWith($link)
+          }
+          else {
+            const $i = document.createElement('i')
+            $i.className = 'fa-solid fa-angle-left collection-nav-item text-secondary'
+            $navItems[0].replaceWith($i)
+          }
+        }
+
+        // Update next link (right arrow)
+        const $nextItem = activeIdx >= 0 && activeIdx < $items.length - 1
+          ? $items[activeIdx + 1].querySelector('a')
+          : null
+        if ($navItems[1]) {
+          if ($nextItem) {
+            const $link = document.createElement('a')
+            $link.href = $nextItem.href
+            $link.className = 'collection-nav-item'
+            $link.rel = 'next'
+            $link.title = $nextItem.title || ''
+            const $i = document.createElement('i')
+            $i.className = 'fa-solid fa-angle-right'
+            $link.appendChild($i)
+            $navItems[1].replaceWith($link)
+          }
+          else {
+            const $i = document.createElement('i')
+            $i.className = 'fa-solid fa-angle-right collection-nav-item text-secondary'
+            $navItems[1].replaceWith($i)
+          }
+        }
+      }, false)
+    })
+  }
+
   /** Convert footnote refs into tooltip-enabled elements. */
   #initFootnotes() {
     const $footnoteRefs = document.querySelectorAll<HTMLElement>('#content sup[id^="fnref:"]')
@@ -171,6 +259,7 @@ export class ContentModule implements ContentService {
     CellTooltip.initAll('.action-btn[title]', { placement: 'bottom' })
     CellTooltip.initAll('.copy-icon-btn[title]', { placement: 'top' })
     CellTooltip.initAll('.fixit-encryptor-btn[title]')
+    CellTooltip.initAll('.collection-sort-toggle[title]', { placement: 'bottom' })
     this.#initFootnotes()
   }
 
@@ -181,6 +270,7 @@ export class ContentModule implements ContentService {
    */
   initContent(target: Element | Document = document) {
     this.initDetails(target)
+    this.initCollectionSort()
     this.#code.initCodeWrapper()
     this.#code.initCodeTabs()
     this.#code.initDiagramCopyBtn()

--- a/assets/scss/core/_rtl.scss
+++ b/assets/scss/core/_rtl.scss
@@ -35,7 +35,9 @@
   .fa-comment-dots,
   .fa-message,
   .fa-retweet,
-  .octicon-report-16 {
+  .octicon-report-16,
+  .fa-arrow-down-wide-short,
+  .fa-arrow-up-short-wide {
     scale: -1 1;
   }
 }

--- a/assets/scss/core/layouts/_wrapper.scss
+++ b/assets/scss/core/layouts/_wrapper.scss
@@ -13,6 +13,7 @@
 
     aside {
       flex: 1;
+      min-width: 0;
       padding: 0.5rem;
       max-width: 500px;
 

--- a/assets/scss/pages/posts/_collections.scss
+++ b/assets/scss/pages/posts/_collections.scss
@@ -126,22 +126,38 @@
     }
 
     .collection-name {
-      flex-grow: 1;
       font-weight: bold;
       font-size: fi-var(collection-title-font-size);
-
-      &::before {
-        content: attr(title) '・';
-      }
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      max-width: fit-content;
     }
 
     .collection-count {
       flex-shrink: 0;
+      flex-grow: 1;
       color: fi-var(global-font-secondary-color);
     }
 
     .details-icon {
       flex-shrink: 0;
+    }
+
+    .collection-sort-toggle {
+      display: flex;
+      align-items: center;
+      flex-shrink: 0;
+      padding: 0.25rem;
+      font-size: 0.75em;
+      color: fi-var(global-font-secondary-color);
+      transition: color 0.2s ease;
+      @include border-radius(full);
+
+      &:hover {
+        color: fi-var(global-font-color);
+        background-color: light-dark(color.adjust($global-background-color, $lightness: -7%), color.adjust($global-background-color-dark, $lightness: 7%));
+      }
     }
   }
 
@@ -191,11 +207,11 @@
 
       a.collection-nav-item {
         padding-inline: 2px;
-        @include border-radius(full);
         transition: background-color 0.3s ease-out;
+        @include border-radius(full);
 
         &:hover {
-          background-color: light-dark(color.adjust($global-background-color, $lightness: -10%), color.adjust($global-background-color-dark, $lightness: 10%));
+          background-color: light-dark(color.adjust($global-background-color, $lightness: -7%), color.adjust($global-background-color-dark, $lightness: 7%));
         }
       }
 

--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -115,6 +115,7 @@ exitFullscreen = "الخروج من ملء الشاشة"
 cookieconsentMessage = "يستخدم هذا الموقع ملفات تعريف الارتباط لتحسين تجربتك."
 cookieconsentDismiss = "فهمت!"
 cookieconsentLink = "اعرف المزيد"
+toggleSortOrder = "تبديل ترتيب الفرز"
 # === Assets ===
 
 # === Share ===

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -114,6 +114,7 @@ exitFullscreen = "Vollbild verlassen"
 cookieconsentMessage = "Diese Website verwendet Cookies, um Ihre Erfahrung zu verbessern."
 cookieconsentDismiss = "Zustimmen"
 cookieconsentLink = "Erfahren Sie mehr"
+toggleSortOrder = "Sortierreihenfolge umschalten"
 # === Assets ===
 
 # === Share ===

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -114,6 +114,7 @@ exitFullscreen = "Exit fullscreen"
 cookieconsentMessage = "This website uses Cookies to improve your experience."
 cookieconsentDismiss = "Got it!"
 cookieconsentLink = "Learn more"
+toggleSortOrder = "Toggle sort order"
 # === Assets ===
 
 # === Share ===

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -114,6 +114,7 @@ exitFullscreen = "Salir de pantalla completa"
 cookieconsentMessage = "Este sitio web utiliza Cookies para mejorar su experiencia."
 cookieconsentDismiss = "De acuerdo"
 cookieconsentLink = "Aprende más"
+toggleSortOrder = "Cambiar orden de clasificación"
 # === Assets ===
 
 # === Share ===

--- a/i18n/fa.toml
+++ b/i18n/fa.toml
@@ -115,6 +115,7 @@ exitFullscreen = "خروج از تمام‌صفحه"
 cookieconsentMessage = "این وبسایت از کوکی‌ها برای بهبود تجربه شما استفاده می‌کند."
 cookieconsentDismiss = "متوجه شدم!"
 cookieconsentLink = "اطلاعات بیشتر"
+toggleSortOrder = "تغییر ترتیب مرتب‌سازی"
 # === Assets ===
 
 # === Share ===

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -114,6 +114,7 @@ exitFullscreen = "Quitter le plein écran"
 cookieconsentMessage = "Ce site Web utilise des Cookies pour améliorer votre expérience."
 cookieconsentDismiss = "J'ai compris !"
 cookieconsentLink = "En apprendre plus"
+toggleSortOrder = "Changer l'ordre de tri"
 # === Assets ===
 
 # === Share ===

--- a/i18n/hi.toml
+++ b/i18n/hi.toml
@@ -115,6 +115,7 @@ exitFullscreen = "पूर्ण स्क्रीन से बाहर न�
 cookieconsentMessage = "यह वेबसाइट आपके अनुभव को बेहतर बनाने के लिए कुकीज़ का उपयोग करती है।"
 cookieconsentDismiss = "समझ गया!"
 cookieconsentLink = "और अधिक जानें"
+toggleSortOrder = "क्रम बदलें"
 # === Assets ===
 
 # === Share ===

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -114,6 +114,7 @@ exitFullscreen = "Esci da schermo intero"
 cookieconsentMessage = "Questo sito Web utilizza i Cookies per migliorare la tua esperienza."
 cookieconsentDismiss = "Essere d'accordo"
 cookieconsentLink = "Per saperne di più"
+toggleSortOrder = "Cambia ordinamento"
 # === Assets ===
 
 # === Share ===

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -112,6 +112,7 @@ exitFullscreen = "全画面を終了"
 cookieconsentMessage = "このウェブサイトはクッキーを使用して体験を向上させます。"
 cookieconsentDismiss = "同意する"
 cookieconsentLink = "詳細はこちら"
+toggleSortOrder = "並べ替え順序の切り替え"
 # === Assets ===
 
 # === Share ===

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -112,6 +112,7 @@ exitFullscreen = "전체 화면 종료"
 cookieconsentMessage = "이 웹사이트는 쿠키를 사용하여 경험을 향상시킵니다."
 cookieconsentDismiss = "동의"
 cookieconsentLink = "자세히 알아보기"
+toggleSortOrder = "정렬 순서 전환"
 # === Assets ===
 
 # === Share ===

--- a/i18n/pl.toml
+++ b/i18n/pl.toml
@@ -114,6 +114,7 @@ exitFullscreen = "Wyjdź z pełnego ekranu"
 cookieconsentMessage = "Ta strona korzysta z plików Cookies, aby poprawić komfort użytkowania."
 cookieconsentDismiss = "Zgodzić się"
 cookieconsentLink = "Ucz się więcej"
+toggleSortOrder = "Zmień kolejność sortowania"
 # === Assets ===
 
 # === Share ===

--- a/i18n/pt-BR.toml
+++ b/i18n/pt-BR.toml
@@ -115,6 +115,7 @@ exitFullscreen = "Sair da tela cheia"
 cookieconsentMessage = "Este site usa Cookies para melhorar sua experiência."
 cookieconsentDismiss = "Aceitar"
 cookieconsentLink = "Saber mais"
+toggleSortOrder = "Alternar ordem de classificação"
 # === Assets ===
 
 # === Share ===

--- a/i18n/ro.toml
+++ b/i18n/ro.toml
@@ -114,6 +114,7 @@ exitFullscreen = "Ieși din ecran complet"
 cookieconsentMessage = "Acest site web utilizează Cookies pentru a vă îmbunătăți experiența."
 cookieconsentDismiss = "De acord"
 cookieconsentLink = "Aflați mai multe"
+toggleSortOrder = "Schimbă ordinea de sortare"
 # === Assets ===
 
 # === Share ===

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -114,6 +114,7 @@ exitFullscreen = "Выйти из полного экрана"
 cookieconsentMessage = "Этот сайт использует Cookies для улучшения вашего опыта."
 cookieconsentDismiss = "Согласен"
 cookieconsentLink = "Учить больше"
+toggleSortOrder = "Переключить порядок сортировки"
 # === Assets ===
 
 # === Share ===

--- a/i18n/sr.toml
+++ b/i18n/sr.toml
@@ -114,6 +114,7 @@ exitFullscreen = "Изађи из целог екрана"
 cookieconsentMessage = "Ова веб локација користи Cookies да би побољшала ваше искуство."
 cookieconsentDismiss = "Договорити се"
 cookieconsentLink = "Сазнајте више"
+toggleSortOrder = "Промени редослед сортирања"
 # === Assets ===
 
 # === Share ===

--- a/i18n/ur.toml
+++ b/i18n/ur.toml
@@ -115,6 +115,7 @@ exitFullscreen = "فل اسکرین سے باہر نکلیں"
 cookieconsentMessage = "یہ ویب سائٹ آپ کے تجربے کو بہتر بنانے کے لیے کوکیز استعمال کرتی ہے۔"
 cookieconsentDismiss = "سمجھ گیا!"
 cookieconsentLink = "مزید جانیں"
+toggleSortOrder = "ترتیب کی ترتیب تبدیل کریں"
 # === Assets ===
 
 # === Share ===

--- a/i18n/vi.toml
+++ b/i18n/vi.toml
@@ -113,6 +113,7 @@ exitFullscreen = "Thoát toàn màn hình"
 cookieconsentMessage = "Trang web này sử dụng Cookies để cải thiện trải nghiệm của bạn."
 cookieconsentDismiss = "Đã hiểu!"
 cookieconsentLink = "Tìm hiểu thêm"
+toggleSortOrder = "Đổi thứ tự sắp xếp"
 # === Assets ===
 
 # === Share ===

--- a/i18n/zh-CN.toml
+++ b/i18n/zh-CN.toml
@@ -112,6 +112,7 @@ exitFullscreen = "退出全屏"
 cookieconsentMessage = "本网站使用 Cookies 来改善你的浏览体验。"
 cookieconsentDismiss = "同意"
 cookieconsentLink = "了解更多"
+toggleSortOrder = "切换排序方式"
 # === Assets ===
 
 # === Share ===

--- a/i18n/zh-TW.toml
+++ b/i18n/zh-TW.toml
@@ -112,6 +112,7 @@ exitFullscreen = "退出全螢幕"
 cookieconsentMessage = "本網站使用 Cookies 來改善你的流覽體驗。"
 cookieconsentDismiss = "同意"
 cookieconsentLink = "瞭解更多"
+toggleSortOrder = "切換排序方式"
 # === Assets ===
 
 # === Share ===

--- a/layouts/_partials/single/collection-list.html
+++ b/layouts/_partials/single/collection-list.html
@@ -2,7 +2,7 @@
 {{- if .Params.collections | and (.Param "collection_list") -}}
   {{- $collectionTerms := .GetTerms "collections" -}}
   {{- range $collectionTerms -}}
-    {{- $pages := (where .Pages "Params.Weight" "!=" nil) | append (where .Pages "Params.Weight" "eq" nil).ByDate -}}
+    {{- $pages := .Pages.ByDate -}}
     {{- $open := eq (index $collectionTerms 0) . -}}
     {{- $currentKey := 0 -}}
     <div class="details collection-details{{ if $open }} open{{ end }}">
@@ -10,6 +10,9 @@
         {{ dict "Class" "fa-solid fa-layer-group" | partial "plugin/icon.html" }}
         <span class="collection-name" title="{{ T "collections" }}">{{ .LinkTitle }}</span>
         <span class="collection-count">{{ $pages.Len }}</span>
+        <button type="button" class="collection-sort-toggle" title="{{ T "assets.toggleSortOrder" }}" aria-label="{{ T "assets.toggleSortOrder" }}">
+          {{- dict "Class" "fa-solid fa-arrow-up-short-wide" | partial "plugin/icon.html" -}}
+        </button>
         {{- dict "Class" "details-icon fa-solid fa-angle-right" | partial "plugin/icon.html" -}}
       </div>
       <div class="details-content collection-content">

--- a/layouts/_partials/single/collection-nav.html
+++ b/layouts/_partials/single/collection-nav.html
@@ -16,8 +16,7 @@
         {{- dict "Collections" $termLink | T "single.includedIn.collections" | strings.FirstUpper | safeHTML }} {{ .Pages.Len -}}
       </div>
       <div class="collection-nav">
-        {{/*  TODO JS 实现 reverse 翻转顺序  */}}
-        {{- $pages := (where .Pages "Params.Weight" "!=" nil) | append (where .Pages "Params.Weight" "eq" nil).ByDate -}}
+        {{- $pages := .Pages.ByDate -}}
         {{- with $pages.Next $ -}}
           {{- $capitalizeTitles := .Param "capitalize_titles" -}}
           {{- $title := .Params.shortTitle | default .LinkTitle -}}


### PR DESCRIPTION
## Summary

- 在 collection-summary 栏添加排序切换按钮，支持实时切换升序/降序
- 简化集合排序逻辑为纯按日期排序（移除 Weight 排序）
- 修复 aside 在长标题下宽度不均的问题

## Changes

- `collection-list.html`: 添加排序切换按钮，简化排序为 `.ByDate`
- `collection-nav.html`: 同步简化排序逻辑
- `content.ts`: 新增 `initCollectionSort` 方法，点击按钮反转列表 DOM 并更新导航
- `tokens.ts`: `ContentService` 接口添加 `initCollectionSort`
- `_collections.scss`: 添加 `.collection-sort-toggle` 按钮样式，优化长标题处理
- `_wrapper.scss`: aside 添加 `min-width: 0` 修复 flex 子项宽度不均
- `i18n/*.toml`: 19 种语言添加 `toggleSortOrder` 翻译

## Test plan

- [x] `pnpm build:demo` 构建通过
- [x] `pnpm build:test` 构建通过
- [x] `pnpm typecheck` 类型检查通过
- [x] `pnpm lint` 通过
- [x] 访问集合页面，确认默认升序排列
- [x] 点击排序按钮，列表实时切换为降序
- [x] 再次点击，切换回升序
- [x] 确认前后篇导航和计数器正确更新
- [x] 确认 CellTooltip 正常显示